### PR TITLE
Add support for Windows Server 2019.

### DIFF
--- a/os_info/Cargo.toml
+++ b/os_info/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4.5"
 serde = { version = "1.0.0", features = ["derive"], optional = true }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.8", features = ["minwindef", "ntdef", "ntstatus", "sysinfoapi", "winnt", "winuser", "libloaderapi", "processthreadsapi"] }
+winapi = { version = "0.3.8", features = ["minwindef", "ntdef", "ntstatus", "sysinfoapi", "winnt", "winuser", "libloaderapi", "processthreadsapi", "winerror", "winreg"] }
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"


### PR DESCRIPTION
As far as I can tell, the best way to differentiate between Server 2016 and Server 2019 is by reading the "release ID" from the Registry.  This pull request adds code to do that.