### PR TITLE
Add support for Windows Server 2019 using ProductName

### DIFF
--- a/os_info/Cargo.toml
+++ b/os_info/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4.5"
 serde = { version = "1.0.0", features = ["derive"], optional = true }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.8", features = ["minwindef", "ntdef", "ntstatus", "sysinfoapi", "winnt", "winuser", "libloaderapi", "processthreadsapi", "winreg"] }
+winapi = { version = "0.3.8", features = ["minwindef", "ntdef", "ntstatus", "sysinfoapi", "winnt", "winuser", "libloaderapi", "processthreadsapi", "winerror", "winreg"] }
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/os_info/Cargo.toml
+++ b/os_info/Cargo.toml
@@ -20,7 +20,7 @@ log = "0.4.5"
 serde = { version = "1.0.0", features = ["derive"], optional = true }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.8", features = ["minwindef", "ntdef", "ntstatus", "sysinfoapi", "winnt", "winuser", "libloaderapi", "processthreadsapi"] }
+winapi = { version = "0.3.8", features = ["minwindef", "ntdef", "ntstatus", "sysinfoapi", "winnt", "winuser", "libloaderapi", "processthreadsapi", "winreg"] }
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/os_info/src/windows/winapi.rs
+++ b/os_info/src/windows/winapi.rs
@@ -18,9 +18,12 @@ use winapi::{
     um::{
         libloaderapi::{GetModuleHandleA, GetProcAddress},
         sysinfoapi::{GetSystemInfo, SYSTEM_INFO},
-        winnt::{KEY_READ, PROCESSOR_ARCHITECTURE_AMD64, REG_SZ, VER_NT_WORKSTATION, VER_SUITE_WH_SERVER, WCHAR},
-        winreg::{HKEY_LOCAL_MACHINE, LSTATUS, RegOpenKeyExW, RegQueryValueExW},
+        winnt::{
+            KEY_READ, PROCESSOR_ARCHITECTURE_AMD64, REG_SZ, VER_NT_WORKSTATION,
+            VER_SUITE_WH_SERVER, WCHAR,
+        },
         winuser::{GetSystemMetrics, SM_SERVERR2},
+        winreg::{HKEY_LOCAL_MACHINE, LSTATUS, RegOpenKeyExW, RegQueryValueExW},
     },
 };
 
@@ -52,7 +55,7 @@ fn version() -> (Version, Option<String>) {
                 v.dwMinorVersion as u64,
                 v.dwBuildNumber as u64,
             ),
-            product_name().or_else(||edition(&v)),
+            product_name().or_else(|| edition(&v)),
         ),
     }
 }

--- a/os_info/src/windows/winapi.rs
+++ b/os_info/src/windows/winapi.rs
@@ -1,6 +1,7 @@
 // spell-checker:ignore dword, minwindef, ntdef, ntdll, ntstatus, osversioninfoex, osversioninfoexa
 // spell-checker:ignore osversioninfoexw, serverr, sysinfoapi, winnt, winuser, pbool, libloaderapi
-// spell-checker:ignore lpcstr, processthreadsapi, farproc, lstatus, wchar, lpbyte
+// spell-checker:ignore lpcstr, processthreadsapi, farproc, lstatus, wchar, lpbyte, hkey, osstr
+// spell-checker:ignore winerror, winreg
 
 #![allow(unsafe_code)]
 
@@ -22,8 +23,8 @@ use winapi::{
             KEY_READ, PROCESSOR_ARCHITECTURE_AMD64, REG_SZ, VER_NT_WORKSTATION,
             VER_SUITE_WH_SERVER, WCHAR,
         },
+        winreg::{RegOpenKeyExW, RegQueryValueExW, HKEY_LOCAL_MACHINE, LSTATUS},
         winuser::{GetSystemMetrics, SM_SERVERR2},
-        winreg::{HKEY_LOCAL_MACHINE, LSTATUS, RegOpenKeyExW, RegQueryValueExW},
     },
 };
 

--- a/os_info/src/windows/winapi.rs
+++ b/os_info/src/windows/winapi.rs
@@ -1,21 +1,25 @@
 // spell-checker:ignore dword, minwindef, ntdef, ntdll, ntstatus, osversioninfoex, osversioninfoexa
 // spell-checker:ignore osversioninfoexw, serverr, sysinfoapi, winnt, winuser, pbool, libloaderapi
-// spell-checker:ignore lpcstr, processthreadsapi, farproc
+// spell-checker:ignore lpcstr, processthreadsapi, farproc, lstatus, wchar, lpbyte
 
 #![allow(unsafe_code)]
 
+use std::ffi::{OsStr, OsString};
 use std::mem;
+use std::os::windows::ffi::{OsStrExt, OsStringExt};
 
 use winapi::{
     shared::{
-        minwindef::{DWORD, FARPROC},
+        minwindef::{DWORD, FARPROC, HKEY, LPBYTE},
         ntdef::{LPCSTR, NTSTATUS},
         ntstatus::STATUS_SUCCESS,
+        winerror::ERROR_SUCCESS,
     },
     um::{
         libloaderapi::{GetModuleHandleA, GetProcAddress},
         sysinfoapi::{GetSystemInfo, SYSTEM_INFO},
-        winnt::{PROCESSOR_ARCHITECTURE_AMD64, VER_NT_WORKSTATION, VER_SUITE_WH_SERVER},
+        winnt::{KEY_READ, PROCESSOR_ARCHITECTURE_AMD64, REG_SZ, VER_NT_WORKSTATION, VER_SUITE_WH_SERVER, WCHAR},
+        winreg::{HKEY_LOCAL_MACHINE, LSTATUS, RegOpenKeyExW, RegQueryValueExW},
         winuser::{GetSystemMetrics, SM_SERVERR2},
     },
 };
@@ -48,7 +52,7 @@ fn version() -> (Version, Option<String>) {
                 v.dwMinorVersion as u64,
                 v.dwBuildNumber as u64,
             ),
-            edition(&v),
+            product_name().or_else(||edition(&v)),
         ),
     }
 }
@@ -112,6 +116,57 @@ fn version_info() -> Option<OSVERSIONINFOEX> {
     } else {
         None
     }
+}
+
+fn str_to_wide(value: &str) -> Vec<WCHAR> {
+    OsStr::new(value).encode_wide().chain(Some(0)).collect()
+}
+
+fn product_name() -> Option<String> {
+    const REG_SUCCESS: LSTATUS = ERROR_SUCCESS as LSTATUS;
+    const MAX_CHARS: usize = 256;
+    // Assume something will go wrong
+    let mut rv = None;
+    // Path as a wide string (array of WCHAR)
+    let sub_key = str_to_wide("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion");
+    // Registry key
+    let mut key: HKEY = std::ptr::null_mut();
+    // Try to open the path for reading (should never fail)
+    if unsafe { RegOpenKeyExW(HKEY_LOCAL_MACHINE, sub_key.as_ptr(), 0, KEY_READ, &mut key) }
+        == REG_SUCCESS
+    {
+        // Name as a wide string
+        let name = str_to_wide("ProductName");
+        // Where we'll be storing
+        let mut data_type: DWORD = 0;
+        let mut data = [0 as WCHAR; MAX_CHARS];
+        let mut data_size: DWORD = std::mem::size_of::<[WCHAR; MAX_CHARS]>() as DWORD;
+        // Try reading the value
+        let status = unsafe {
+            RegQueryValueExW(
+                key,
+                name.as_ptr(),
+                std::ptr::null_mut(),
+                &mut data_type,
+                &mut data as *mut _ as LPBYTE,
+                &mut data_size,
+            )
+        };
+        // Success and the correct datatype?
+        if status == REG_SUCCESS && data_type == REG_SZ {
+            // RegQueryValueExW returns the number of bytes stored including the null terminator.
+            // We want the string length without the terminator.
+            let string_length = (data_size as usize / std::mem::size_of::<WCHAR>()) - 1;
+            let as_slice =
+                unsafe { std::slice::from_raw_parts(&data as *const WCHAR, string_length) };
+            // Convert to a dirty UTF-8 string
+            let osstr: OsString = OsStringExt::from_wide(as_slice);
+            // Drop invalid characters and ensure we own it.  Finally.  A clean Rust string.
+            let value = osstr.to_string_lossy().to_string();
+            rv = Some(value);
+        }
+    }
+    rv
 }
 
 // Examines data in the OSVERSIONINFOEX structure to determine the Windows edition:


### PR DESCRIPTION
This is an alternative that favours `ProductName` from the Registry for `edition`.