### PR TITLE
Update deadlinks invocation [CI]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,9 +69,9 @@ jobs:
       - name: Install deadlinks
         run: cargo install cargo-deadlinks
       - name: Cargo doc
-        run: cargo doc --no-deps
+        run: cargo doc --no-deps -p os_info
       - name: Run deadlinks
-        run: cargo deadlinks --dir target/doc
+        run: cargo deadlinks
 
   # Check links in markdown files.
   mlc:


### PR DESCRIPTION
- Generate docs only for the library crate.
- Remove `--dir` parameter for deadlinks because the https://github.com/deadlinks/cargo-deadlinks/issues/9 issue is fixed.