### PR TITLE
fix: allow deserialize from anycase

### DIFF
--- a/os_info/src/os_type.rs
+++ b/os_info/src/os_type.rs
@@ -3,6 +3,7 @@ use std::fmt::{self, Display, Formatter};
 /// A list of supported operating system types.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[serde(rename_all = "lowercase")]
 #[allow(non_camel_case_types)]
 #[non_exhaustive]
 pub enum Type {


### PR DESCRIPTION
This macro allows Serde to load a YAML representation of an `os_info::Type` and deserialise it, regardless of the case used within the YAML.

This shouldn't affect anything when not loading from YAML 👍🏻 