### PR TITLE
Implement support for FreeBSD operating system

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Right now, the following operating system types can be returned:
 - Emscripten
 - EndeavourOS
 - Fedora
+- FreeBSD
 - Linux
 - Linux Mint
 - macOS (Mac OS X or OS X)

--- a/os_info/src/bitness.rs
+++ b/os_info/src/bitness.rs
@@ -1,7 +1,7 @@
 // spell-checker:ignore getconf
 
 use std::fmt::{self, Display, Formatter};
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
 use std::process::{Command, Output};
 
 /// Operating system architecture in terms of how many bits compose the basic values it can deal with.
@@ -27,7 +27,7 @@ impl Display for Bitness {
     }
 }
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
 pub fn get() -> Bitness {
     match &Command::new("getconf").arg("LONG_BIT").output() {
         Ok(Output { stdout, .. }) if stdout == b"32\n" => Bitness::X32,
@@ -36,7 +36,7 @@ pub fn get() -> Bitness {
     }
 }
 
-#[cfg(all(test, any(target_os = "linux", target_os = "macos")))]
+#[cfg(all(test, any(target_os = "linux", target_os = "freebsd", target_os = "macos")))]
 mod tests {
     use super::*;
     use pretty_assertions::assert_ne;

--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -1,0 +1,43 @@
+use crate::{bitness, Info, Type, Version};
+use std::process::Command;
+
+fn uname(arg: &str) -> Option<String> {
+    Command::new("uname")
+        .args(&[arg])
+        .output()
+        .ok()
+        .and_then(|out| {
+            if out.status.success() {
+                String::from_utf8(out.stdout)
+                    .ok()
+                    .map(|sz| sz.trim_end().to_string())
+            } else {
+                None
+            }
+        })
+}
+
+pub fn current_platform() -> Info {
+    let version = uname("-r")
+        .map(Version::from_string)
+        .unwrap_or_else(|| Version::Unknown);
+    let info = Info {
+        os_type: Type::FreeBSD,
+        version,
+        bitness: bitness::get(),
+        ..Default::default()
+    };
+    info
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn os_type() {
+        let version = current_platform();
+        assert_eq!(Type::FreeBSD, version.os_type());
+    }
+}

--- a/os_info/src/lib.rs
+++ b/os_info/src/lib.rs
@@ -18,6 +18,10 @@ mod imp;
 #[path = "emscripten/mod.rs"]
 mod imp;
 
+#[cfg(target_os = "freebsd")]
+#[path = "freebsd/mod.rs"]
+mod imp;
+
 #[cfg(target_os = "linux")]
 #[path = "linux/mod.rs"]
 mod imp;
@@ -37,6 +41,7 @@ mod imp;
 #[cfg(not(any(
     target_os = "android",
     target_os = "emscripten",
+    target_os = "freebsd",
     target_os = "linux",
     target_os = "macos",
     target_os = "redox",

--- a/os_info/src/os_type.rs
+++ b/os_info/src/os_type.rs
@@ -24,6 +24,8 @@ pub enum Type {
     EndeavourOS,
     /// Fedora (<https://en.wikipedia.org/wiki/Fedora_(operating_system)>).
     Fedora,
+    /// FreeBSD operating system (<https://en.wikipedia.org/wiki/FreeBSD>).
+    FreeBSD,
     /// Linux based operating system (<https://en.wikipedia.org/wiki/Linux>).
     Linux,
     /// Mac OS X/OS X/macOS (<https://en.wikipedia.org/wiki/MacOS>).
@@ -100,6 +102,7 @@ mod tests {
             (Type::Emscripten, "Emscripten"),
             (Type::EndeavourOS, "EndeavourOS"),
             (Type::Fedora, "Fedora"),
+            (Type::FreeBSD, "FreeBSD"),
             (Type::Linux, "Linux"),
             (Type::Macos, "Mac OS"),
             (Type::Manjaro, "Manjaro"),


### PR DESCRIPTION
Fixes #246

Signed-off-by: Ashish SHUKLA <ashish.is@lostca.se>

Tested on `FreeBSD 11.4`:

```
λ uname -r
11.4-RELEASE-p3
λ uname -m
amd64
λ getconf LONG_BIT
64
λ ./os_info
OS information:
Type: FreeBSD
Version: 11.4-RELEASE-p3
Bitness: 64-bit
```

And `FreeBSD 13.0-RC2`:

```
λ uname -r
13.0-RC2
λ uname -m
amd64
λ getconf LONG_BIT
64
λ ./os_info
OS information:
Type: FreeBSD
Version: 13.0-RC2
Bitness: 64-bit
```