### PR TITLE
Add support for DragonFly BSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Right now, the following operating system types can be returned:
 - Arch Linux
 - CentOS
 - Debian
+- DragonFly BSD
 - Emscripten
 - EndeavourOS
 - Fedora

--- a/os_info/src/dflybsd/mod.rs
+++ b/os_info/src/dflybsd/mod.rs
@@ -1,0 +1,43 @@
+use crate::{Bitness, Info, Type, Version};
+use std::process::Command;
+
+fn uname(arg: &str) -> Option<String> {
+    Command::new("uname")
+        .args(&[arg])
+        .output()
+        .ok()
+        .and_then(|out| {
+            if out.status.success() {
+                String::from_utf8(out.stdout)
+                    .ok()
+                    .map(|sz| sz.trim_end().to_string())
+            } else {
+                None
+            }
+        })
+}
+
+pub fn current_platform() -> Info {
+    let version = uname("-r")
+        .map(Version::from_string)
+        .unwrap_or_else(|| Version::Unknown);
+    let info = Info {
+        os_type: Type::DragonFly,
+        version,
+        bitness: Bitness::X64,
+        ..Default::default()
+    };
+    info
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn os_type() {
+        let version = current_platform();
+        assert_eq!(Type::DragonFly, version.os_type());
+    }
+}

--- a/os_info/src/lib.rs
+++ b/os_info/src/lib.rs
@@ -14,6 +14,10 @@
 #[path = "android/mod.rs"]
 mod imp;
 
+#[cfg(target_os = "dragonfly")]
+#[path = "dflybsd/mod.rs"]
+mod imp;
+
 #[cfg(target_os = "emscripten")]
 #[path = "emscripten/mod.rs"]
 mod imp;
@@ -40,6 +44,7 @@ mod imp;
 
 #[cfg(not(any(
     target_os = "android",
+    target_os = "dragonfly",
     target_os = "emscripten",
     target_os = "freebsd",
     target_os = "linux",

--- a/os_info/src/os_type.rs
+++ b/os_info/src/os_type.rs
@@ -18,6 +18,8 @@ pub enum Type {
     CentOS,
     /// Debian (<https://en.wikipedia.org/wiki/Debian>).
     Debian,
+    /// DragonFly BSD operating system (<https://en.wikipedia.org/wiki/DragonFly_BSD>).
+    DragonFly,
     /// Emscripten (<https://en.wikipedia.org/wiki/Emscripten>).
     Emscripten,
     /// EndeavourOS (<https://en.wikipedia.org/wiki/EndeavourOS>).
@@ -72,6 +74,7 @@ impl Display for Type {
             Type::Alpine => write!(f, "Alpine Linux"),
             Type::Amazon => write!(f, "Amazon Linux AMI"),
             Type::Arch => write!(f, "Arch Linux"),
+            Type::DragonFly => write!(f, "DragonFly BSD"),
             Type::Macos => write!(f, "Mac OS"),
             Type::Mint => write!(f, "Linux Mint"),
             Type::Pop => write!(f, "Pop!_OS"),
@@ -101,6 +104,7 @@ mod tests {
             (Type::Arch, "Arch Linux"),
             (Type::CentOS, "CentOS"),
             (Type::Debian, "Debian"),
+            (Type::DragonFly, "DragonFly BSD"),
             (Type::Emscripten, "Emscripten"),
             (Type::EndeavourOS, "EndeavourOS"),
             (Type::Fedora, "Fedora"),


### PR DESCRIPTION
As DragonFly BSD is pretty similar to FreeBSD regarding what os_info needs to know, I gave adding it a try. This PR is basically copy 'n' paste with one very minor change (the OS is 64-bit only). All the actual work was done by **wahjava** for the FreeBSD support that I used as the reference for this.

Cargo compiles the source and the output of the cli tool on a machine running DF is as expected. However I cannot judge if the code requires more changes to be acceptable, I don't have any actual coding skills and am not familiar with developing in Rust.