### PR TITLE
Enable required use for Command, Output to fix build on DragonFly BSD

### DIFF
--- a/os_info/src/bitness.rs
+++ b/os_info/src/bitness.rs
@@ -1,7 +1,7 @@
 // spell-checker:ignore getconf
 
 use std::fmt::{self, Display, Formatter};
-#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos"))]
+#[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "macos", target_os = "dragonfly"))]
 use std::process::{Command, Output};
 
 /// Operating system architecture in terms of how many bits compose the basic values it can deal with.


### PR DESCRIPTION
There's currently one thing missing for os_info to work on DragonFly BSD: The build fails as `std::process::Command` and `std::process::Output` are unavailable on that platform. This commit enables both and makes os_info work as intended on DF.