### PR TITLE
Fix #272, Add in support for bitness for NetBSD

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -1,3 +1,4 @@
+aarch64
 bitness
 centos
 clippy

--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -3,6 +3,7 @@ bitness
 centos
 clippy
 concat
+earmv
 emscripten
 endeavouros
 freebsd

--- a/os_info/src/bitness.rs
+++ b/os_info/src/bitness.rs
@@ -41,6 +41,18 @@ impl Display for Bitness {
     target_os = "netbsd"
 ))]
 pub fn get() -> Bitness {
+
+    if cfg!(target_os = "netbsd") {
+        let bitness =  match &Command::new("sysctl").arg("-n").arg("hw.machine_arch").output() {
+            Ok(Output { stdout, .. }) if stdout == b"amd64\n" => Bitness::X64,
+            Ok(Output { stdout, .. }) if stdout == b"x86_64\n" => Bitness::X64,
+            Ok(Output { stdout, .. }) if stdout == b"i386\n" => Bitness::X32,
+            Ok(Output { stdout, .. }) if stdout == b"aarch64\n" => Bitness::X64,
+            _ => Bitness::Unknown
+        };
+        return bitness;
+    }
+
     match &Command::new("getconf").arg("LONG_BIT").output() {
         Ok(Output { stdout, .. }) if stdout == b"32\n" => Bitness::X32,
         Ok(Output { stdout, .. }) if stdout == b"64\n" => Bitness::X64,

--- a/os_info/src/bitness.rs
+++ b/os_info/src/bitness.rs
@@ -51,6 +51,7 @@ pub fn get() -> Bitness {
             Ok(Output { stdout, .. }) if stdout == b"x86_64\n" => Bitness::X64,
             Ok(Output { stdout, .. }) if stdout == b"i386\n" => Bitness::X32,
             Ok(Output { stdout, .. }) if stdout == b"aarch64\n" => Bitness::X64,
+            Ok(Output { stdout, .. }) if stdout == b"earmv7hf\n" => Bitness::X32,
             _ => Bitness::Unknown,
         };
         return bitness;

--- a/os_info/src/bitness.rs
+++ b/os_info/src/bitness.rs
@@ -43,12 +43,15 @@ impl Display for Bitness {
 pub fn get() -> Bitness {
 
     if cfg!(target_os = "netbsd") {
-        let bitness =  match &Command::new("sysctl").arg("-n").arg("hw.machine_arch").output() {
+        let bitness =  match &Command::new("sysctl")
+            .arg("-n")
+            .arg("hw.machine_arch")
+            .output() {
             Ok(Output { stdout, .. }) if stdout == b"amd64\n" => Bitness::X64,
             Ok(Output { stdout, .. }) if stdout == b"x86_64\n" => Bitness::X64,
             Ok(Output { stdout, .. }) if stdout == b"i386\n" => Bitness::X32,
             Ok(Output { stdout, .. }) if stdout == b"aarch64\n" => Bitness::X64,
-            _ => Bitness::Unknown
+            _ => Bitness::Unknown,
         };
         return bitness;
     }

--- a/os_info/src/bitness.rs
+++ b/os_info/src/bitness.rs
@@ -41,12 +41,12 @@ impl Display for Bitness {
     target_os = "netbsd"
 ))]
 pub fn get() -> Bitness {
-
     if cfg!(target_os = "netbsd") {
-        let bitness =  match &Command::new("sysctl")
+        let bitness = match &Command::new("sysctl")
             .arg("-n")
             .arg("hw.machine_arch")
-            .output() {
+            .output()
+        {
             Ok(Output { stdout, .. }) if stdout == b"amd64\n" => Bitness::X64,
             Ok(Output { stdout, .. }) if stdout == b"x86_64\n" => Bitness::X64,
             Ok(Output { stdout, .. }) if stdout == b"i386\n" => Bitness::X32,


### PR DESCRIPTION
As per issue #272,

Add in support for bitness for NetBSD during run time. FreeBSD and DragonFlyBSD use "getconf." NetBSD uses "sysctl."

Has to read the "hw.machine_arch" property in sysctl. Then using a machine, it will take certain architectures such as x86_64 and return that bitness is 64 bit.

Supported architectures currently:
- amd64
- i386
- x86_64
- aarch64
- armv7hf
 
Other architectures should be easy to implement upon request.

<img width="476" alt="Screen Shot 2021-12-01 at 11 05 04 PM" src="https://user-images.githubusercontent.com/33560895/144374353-7a7fbaef-bc06-4476-bb5b-a5332b46f450.png">

