### PR TITLE
OpenBSD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Right now, the following operating system types can be returned:
 - Manjaro
 - NetBSD
 - NixOS
+- OpenBSD
 - openSUSE
 - Oracle Linux
 - Pop!_OS

--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -14,6 +14,7 @@ manjaro
 msvc
 netbsd
 nixos
+openbsd
 println
 raspberry
 raspbian

--- a/os_info/src/bitness.rs
+++ b/os_info/src/bitness.rs
@@ -6,7 +6,8 @@ use std::fmt::{self, Display, Formatter};
     target_os = "freebsd",
     target_os = "linux",
     target_os = "macos",
-    target_os = "netbsd"
+    target_os = "netbsd",
+    target_os = "openbsd"
 ))]
 use std::process::{Command, Output};
 
@@ -38,6 +39,7 @@ impl Display for Bitness {
     target_os = "freebsd",
     target_os = "linux",
     target_os = "macos",
+    target_os = "openbsd"
 ))]
 pub fn get() -> Bitness {
     match &Command::new("getconf").arg("LONG_BIT").output() {
@@ -71,6 +73,7 @@ pub fn get() -> Bitness {
         target_os = "linux",
         target_os = "macos",
         target_os = "netbsd",
+        target_os = "openbsd"
     )
 ))]
 mod tests {

--- a/os_info/src/bitness.rs
+++ b/os_info/src/bitness.rs
@@ -66,7 +66,7 @@ pub fn get() -> Bitness {
 
 #[cfg(target_os = "openbsd")]
 pub fn get() -> Bitness {
-    match &Command::new("sysctl").arg("-n").arg("hw.machine).output() {
+    match &Command::new("sysctl").arg("-n").arg("hw.machine").output() {
     {
         Ok(Output { stdout, .. }) if stdout == b"amd64\n" => Bitness::X64,
         Ok(Output { stdout, .. }) if stdout == b"x86_64\n" => Bitness::X64,

--- a/os_info/src/bitness.rs
+++ b/os_info/src/bitness.rs
@@ -66,10 +66,7 @@ pub fn get() -> Bitness {
 
 #[cfg(target_os = "openbsd")]
 pub fn get() -> Bitness {
-    match &Command::new("sysctl")
-        .arg("-n")
-        .arg("hw.machine")
-        .output()
+    match &Command::new("sysctl").arg("-n").arg("hw.machine).output() {
     {
         Ok(Output { stdout, .. }) if stdout == b"amd64\n" => Bitness::X64,
         Ok(Output { stdout, .. }) if stdout == b"x86_64\n" => Bitness::X64,

--- a/os_info/src/bitness.rs
+++ b/os_info/src/bitness.rs
@@ -67,7 +67,6 @@ pub fn get() -> Bitness {
 #[cfg(target_os = "openbsd")]
 pub fn get() -> Bitness {
     match &Command::new("sysctl").arg("-n").arg("hw.machine").output() {
-    {
         Ok(Output { stdout, .. }) if stdout == b"amd64\n" => Bitness::X64,
         Ok(Output { stdout, .. }) if stdout == b"x86_64\n" => Bitness::X64,
         Ok(Output { stdout, .. }) if stdout == b"i386\n" => Bitness::X32,

--- a/os_info/src/bitness.rs
+++ b/os_info/src/bitness.rs
@@ -39,7 +39,6 @@ impl Display for Bitness {
     target_os = "freebsd",
     target_os = "linux",
     target_os = "macos",
-    target_os = "openbsd"
 ))]
 pub fn get() -> Bitness {
     match &Command::new("getconf").arg("LONG_BIT").output() {
@@ -54,6 +53,22 @@ pub fn get() -> Bitness {
     match &Command::new("sysctl")
         .arg("-n")
         .arg("hw.machine_arch")
+        .output()
+    {
+        Ok(Output { stdout, .. }) if stdout == b"amd64\n" => Bitness::X64,
+        Ok(Output { stdout, .. }) if stdout == b"x86_64\n" => Bitness::X64,
+        Ok(Output { stdout, .. }) if stdout == b"i386\n" => Bitness::X32,
+        Ok(Output { stdout, .. }) if stdout == b"aarch64\n" => Bitness::X64,
+        Ok(Output { stdout, .. }) if stdout == b"earmv7hf\n" => Bitness::X32,
+        _ => Bitness::Unknown,
+    }
+}
+
+#[cfg(target_os = "openbsd")]
+pub fn get() -> Bitness {
+    match &Command::new("sysctl")
+        .arg("-n")
+        .arg("hw.machine")
         .output()
     {
         Ok(Output { stdout, .. }) if stdout == b"amd64\n" => Bitness::X64,

--- a/os_info/src/lib.rs
+++ b/os_info/src/lib.rs
@@ -70,7 +70,7 @@ mod info;
 #[cfg(not(windows))]
 mod matcher;
 mod os_type;
-#[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd"))]
+#[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os="openbsd"))]
 mod uname;
 mod version;
 

--- a/os_info/src/lib.rs
+++ b/os_info/src/lib.rs
@@ -70,7 +70,12 @@ mod info;
 #[cfg(not(windows))]
 mod matcher;
 mod os_type;
-#[cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "netbsd", target_os="openbsd"))]
+#[cfg(any(
+    target_os = "dragonfly",
+    target_os = "freebsd",
+    target_os = "netbsd",
+    target_os = "openbsd"
+))]
 mod uname;
 mod version;
 

--- a/os_info/src/lib.rs
+++ b/os_info/src/lib.rs
@@ -38,6 +38,10 @@ mod imp;
 #[path = "netbsd/mod.rs"]
 mod imp;
 
+#[cfg(target_os = "openbsd")]
+#[path = "openbsd/mod.rs"]
+mod imp;
+
 #[cfg(target_os = "redox")]
 #[path = "redox/mod.rs"]
 mod imp;
@@ -54,6 +58,7 @@ mod imp;
     target_os = "linux",
     target_os = "macos",
     target_os = "netbsd",
+    target_os = "openbsd",
     target_os = "redox",
     target_os = "windows"
 )))]

--- a/os_info/src/openbsd/mod.rs
+++ b/os_info/src/openbsd/mod.rs
@@ -1,0 +1,35 @@
+use std::process::Command;
+
+use log::{error, trace};
+
+use crate::{bitness, uname::uname, Info, Type, Version};
+
+pub fn current_platform() -> Info {
+    trace!("openbsd::current_platform is called");
+
+    let version = uname()
+        .map(Version::from_string)
+        .unwrap_or_else(|| Version::Unknown);
+
+    let info = Info {
+        os_type: Type::OpenBSD,
+        version,
+        bitness: bitness::get(),
+        ..Default::default()
+    };
+
+    trace!("Returning {:?}", info);
+    info
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn os_type() {
+        let version = current_platform();
+        assert_eq!(Type::OpenBSD, version.os_type());
+    }
+}

--- a/os_info/src/os_type.rs
+++ b/os_info/src/os_type.rs
@@ -40,6 +40,8 @@ pub enum Type {
     NetBSD,
     /// NixOS (<https://en.wikipedia.org/wiki/NixOS>).
     NixOS,
+    /// OpenBSD (<https://en.wikipedia.org/wiki/OpenBSD>).
+    OpenBSD,
     /// openSUSE (<https://en.wikipedia.org/wiki/OpenSUSE>).
     openSUSE,
     /// Oracle Linux (<https://en.wikipedia.org/wiki/Oracle_Linux>).
@@ -120,6 +122,7 @@ mod tests {
             (Type::Mint, "Linux Mint"),
             (Type::NetBSD, "NetBSD"),
             (Type::NixOS, "NixOS"),
+            (Type::OpenBSD, "OpenBSD"),
             (Type::openSUSE, "openSUSE"),
             (Type::OracleLinux, "OracleLinux"),
             (Type::Pop, "Pop!_OS"),


### PR DESCRIPTION
This pull request brings in OpenBSD support to OS_info.

Support has been tested for both 64 and 32-bit x86 architectures. 

<img width="504" alt="Screen Shot 2022-01-03 at 2 03 19 AM" src="https://user-images.githubusercontent.com/33560895/148034041-48bf5c9b-25f8-47f2-b68d-99300f5ee98c.png">

