### PR TITLE
Midnight bsd support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Right now, the following operating system types can be returned:
 - Linux Mint
 - macOS (Mac OS X or OS X)
 - Manjaro
+- MidnightBSD
 - NetBSD
 - NixOS
 - OpenBSD

--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -11,6 +11,7 @@ libntdll
 linuxmint
 macos
 manjaro
+midnightbsd
 msvc
 netbsd
 nixos

--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -22,6 +22,10 @@ pub fn current_platform() -> Info {
     info
 }
 
+fn get_os () -> Type {
+    let os = Command::new("uname").arg("-s").output().expect();
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -26,7 +26,7 @@ pub fn current_platform() -> Info {
 fn get_os () -> Type {
     let os = Command::new("uname").arg("-s").output().expect("Failed to get OS");
 
-    match str::from_ut8(&os.stdout).unwrap() {
+    match str::from_utf8(&os.stdout).unwrap() {
         "FreeBSD\n" => Type::FreeBSD,
         "MidnightBSD\n" => Type::MidnightBSD,
         _ => Type::Unknown

--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -1,4 +1,5 @@
 use std::process::Command;
+use std::str;
 
 use log::{error, trace};
 
@@ -12,7 +13,7 @@ pub fn current_platform() -> Info {
         .unwrap_or_else(|| Version::Unknown);
 
     let info = Info {
-        os_type: Type::FreeBSD,
+        os_type: get_os(),
         version,
         bitness: bitness::get(),
         ..Default::default()
@@ -23,7 +24,13 @@ pub fn current_platform() -> Info {
 }
 
 fn get_os () -> Type {
-    let os = Command::new("uname").arg("-s").output().expect();
+    let os = Command::new("uname").arg("-s").output().expect("Failed to get OS");
+
+    match str::from_ut8(&os.stdout).unwrap() {
+        "FreeBSD\n" => Type::FreeBSD,
+        "MidnightBSD\n" => Type::MidnightBSD,
+        _ => Type::Unknown
+    }
 }
 
 #[cfg(test)]

--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -24,12 +24,15 @@ pub fn current_platform() -> Info {
 }
 
 fn get_os () -> Type {
-    let os = Command::new("uname").arg("-s").output().expect("Failed to get OS");
+    let os = Command::new("uname")
+        .arg("-s")
+        .output()
+        .expect("Failed to get OS");
 
     match str::from_utf8(&os.stdout).unwrap() {
         "FreeBSD\n" => Type::FreeBSD,
         "MidnightBSD\n" => Type::MidnightBSD,
-        _ => Type::Unknown
+        _ => Type::Unknown,
     }
 }
 

--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -23,7 +23,7 @@ pub fn current_platform() -> Info {
     info
 }
 
-fn get_os () -> Type {
+fn get_os() -> Type {
     let os = Command::new("uname")
         .arg("-s")
         .output()

--- a/os_info/src/os_type.rs
+++ b/os_info/src/os_type.rs
@@ -35,6 +35,8 @@ pub enum Type {
     /// Manjaro (<https://en.wikipedia.org/wiki/Manjaro>).
     Manjaro,
     /// Mint (<https://en.wikipedia.org/wiki/Linux_Mint>).
+    MidnightBSD,
+    /// MidnightBSD(<https://en.wikipedia.org/wiki/MidnightBSD>).
     Mint,
     /// NetBSD (<https://en.wikipedia.org/wiki/NetBSD>).
     NetBSD,
@@ -82,6 +84,7 @@ impl Display for Type {
             Type::Arch => write!(f, "Arch Linux"),
             Type::DragonFly => write!(f, "DragonFly BSD"),
             Type::Macos => write!(f, "Mac OS"),
+            Type::MidnightBSD => write!(f, "Midnight BSD"),
             Type::Mint => write!(f, "Linux Mint"),
             Type::Pop => write!(f, "Pop!_OS"),
             Type::Raspbian => write!(f, "Raspberry Pi OS"),
@@ -119,6 +122,7 @@ mod tests {
             (Type::Linux, "Linux"),
             (Type::Macos, "Mac OS"),
             (Type::Manjaro, "Manjaro"),
+            (Type::MidnightBSD, "MidnightBSD"),
             (Type::Mint, "Linux Mint"),
             (Type::NetBSD, "NetBSD"),
             (Type::NixOS, "NixOS"),

--- a/os_info/src/os_type.rs
+++ b/os_info/src/os_type.rs
@@ -122,7 +122,6 @@ mod tests {
             (Type::Linux, "Linux"),
             (Type::Macos, "Mac OS"),
             (Type::Manjaro, "Manjaro"),
-            (Type::MidnightBSD, "MidnightBSD"),
             (Type::Mint, "Linux Mint"),
             (Type::NetBSD, "NetBSD"),
             (Type::NixOS, "NixOS"),


### PR DESCRIPTION
Added support for Midnight BSD. MidnightBSD previously showed up as FreeBSD, this introduces an exclusive function to `freebsd/mod.rs` to get the type by looking at `uname -s`. 
