### PR TITLE
Detect bitness on Sparc64 NetBSD / OpenBSD

### DIFF
--- a/os_info/src/bitness.rs
+++ b/os_info/src/bitness.rs
@@ -60,6 +60,7 @@ pub fn get() -> Bitness {
         Ok(Output { stdout, .. }) if stdout == b"i386\n" => Bitness::X32,
         Ok(Output { stdout, .. }) if stdout == b"aarch64\n" => Bitness::X64,
         Ok(Output { stdout, .. }) if stdout == b"earmv7hf\n" => Bitness::X32,
+        Ok(Output { stdout, .. }) if stdout == b"sparc64\n" => Bitness::X64,
         _ => Bitness::Unknown,
     }
 }
@@ -72,6 +73,7 @@ pub fn get() -> Bitness {
         Ok(Output { stdout, .. }) if stdout == b"i386\n" => Bitness::X32,
         Ok(Output { stdout, .. }) if stdout == b"aarch64\n" => Bitness::X64,
         Ok(Output { stdout, .. }) if stdout == b"earmv7hf\n" => Bitness::X32,
+        Ok(Output { stdout, .. }) if stdout == b"sparc64\n" => Bitness::X64,
         _ => Bitness::Unknown,
     }
 }


### PR DESCRIPTION
This adds bitness detection for the SPARC v9 platform on both NetBSD and OpenBSD. Both cases were tested successfully on real metal.