### PR TITLE
HardenedBSD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Right now, the following operating system types can be returned:
 - EndeavourOS
 - Fedora
 - FreeBSD
+- HardenedBSD
 - Linux
 - Linux Mint
 - macOS (Mac OS X or OS X)

--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -7,6 +7,7 @@ earmv
 emscripten
 endeavouros
 freebsd
+hardenedbsd
 libntdll
 linuxmint
 macos

--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -8,6 +8,7 @@ emscripten
 endeavouros
 freebsd
 hardenedbsd
+hbsd
 libntdll
 linuxmint
 macos

--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -13,7 +13,7 @@ pub fn current_platform() -> Info {
         .unwrap_or_else(|| Version::Unknown);
 
     let info = Info {
-        os_type: get_os(version),
+        os_type: get_os(version.toString()),
         version,
         bitness: bitness::get(),
         ..Default::default()
@@ -33,9 +33,9 @@ fn get_os(ver: String) -> Type {
         "FreeBSD\n" => {
             if ver.contains("HBSD") {
                 println!("Got hardened");
-                Type::FreeBSD
+                return Type::FreeBSD
             }
-            Type::FreeBSD
+            return Type::FreeBSD
         }
         "MidnightBSD\n" => Type::MidnightBSD,
         _ => Type::Unknown,

--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -39,7 +39,7 @@ fn get_os() -> Type {
                 "" => return Type::HardenedBSD,
                 _ => return Type::FreeBSD,
             }
-        },
+        }
         "MidnightBSD\n" => Type::MidnightBSD,
         _ => Type::Unknown,
     }

--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -13,7 +13,7 @@ pub fn current_platform() -> Info {
         .unwrap_or_else(|| Version::Unknown);
 
     let info = Info {
-        os_type: get_os(version.toString()),
+        os_type: get_os(version.to_string()),
         version,
         bitness: bitness::get(),
         ..Default::default()

--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -13,7 +13,7 @@ pub fn current_platform() -> Info {
         .unwrap_or_else(|| Version::Unknown);
 
     let info = Info {
-        os_type: get_os(),
+        os_type: get_os(version),
         version,
         bitness: bitness::get(),
         ..Default::default()
@@ -23,14 +23,20 @@ pub fn current_platform() -> Info {
     info
 }
 
-fn get_os() -> Type {
-    let os = Command::new("uname")
+fn get_os(ver: String) -> Type {
+    let mut os = Command::new("uname")
         .arg("-s")
         .output()
         .expect("Failed to get OS");
 
     match str::from_utf8(&os.stdout).unwrap() {
-        "FreeBSD\n" => Type::FreeBSD,
+        "FreeBSD\n" => {
+            if ver.contains("HBSD") {
+                println!("Got hardened");
+                Type::FreeBSD
+            }
+            Type::FreeBSD
+        }
         "MidnightBSD\n" => Type::MidnightBSD,
         _ => Type::Unknown,
     }

--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -32,7 +32,6 @@ fn get_os(ver: String) -> Type {
     match str::from_utf8(&os.stdout).unwrap() {
         "FreeBSD\n" => {
             if ver.contains("HBSD") {
-                println!("Got hardened");
                 return Type::HardenedBSD
             }
             return Type::FreeBSD

--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -33,7 +33,7 @@ fn get_os(ver: String) -> Type {
         "FreeBSD\n" => {
             if ver.contains("HBSD") {
                 println!("Got hardened");
-                return Type::FreeBSD
+                return Type::HardenedBSD
             }
             return Type::FreeBSD
         }

--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -24,7 +24,7 @@ pub fn current_platform() -> Info {
 }
 
 fn get_os(ver: String) -> Type {
-    let mut os = Command::new("uname")
+    let os = Command::new("uname")
         .arg("-s")
         .output()
         .expect("Failed to get OS");

--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -32,9 +32,9 @@ fn get_os(ver: String) -> Type {
     match str::from_utf8(&os.stdout).unwrap() {
         "FreeBSD\n" => {
             if ver.contains("HBSD") {
-                return Type::HardenedBSD
+                return Type::HardenedBSD;
             }
-            return Type::FreeBSD
+            return Type::FreeBSD;
         }
         "MidnightBSD\n" => Type::MidnightBSD,
         _ => Type::Unknown,

--- a/os_info/src/os_type.rs
+++ b/os_info/src/os_type.rs
@@ -29,6 +29,8 @@ pub enum Type {
     /// FreeBSD (<https://en.wikipedia.org/wiki/FreeBSD>).
     FreeBSD,
     /// Linux based operating system (<https://en.wikipedia.org/wiki/Linux>).
+    HardenedBSD,
+    /// HardenedBSD (https://hardenedbsd.org/)
     Linux,
     /// Mac OS X/OS X/macOS (<https://en.wikipedia.org/wiki/MacOS>).
     Macos,


### PR DESCRIPTION
Support for recognizing HardenedBSD. Done by using the string form of version. HardenedBSD shows FreeBSD when running `uname -s,` however it shows HBSD in the version output by `uname -r.`
