### PR TITLE
Update os_type.rs ,  enum can be as u8 . Unknown place first, and it will be the number 0. I think it is appropriate to use 0 to identify unknown systems.

### DIFF
--- a/os_info/src/os_type.rs
+++ b/os_info/src/os_type.rs
@@ -6,6 +6,8 @@ use std::fmt::{self, Display, Formatter};
 #[allow(non_camel_case_types, clippy::upper_case_acronyms)]
 #[non_exhaustive]
 pub enum Type {
+    /// Unknown operating system.
+    Unknown,
     /// Alpine Linux (<https://en.wikipedia.org/wiki/Alpine_Linux>).
     Alpine,
     /// Amazon Linux AMI (<https://en.wikipedia.org/wiki/Amazon_Machine_Image#Amazon_Linux_AMI>).
@@ -64,8 +66,6 @@ pub enum Type {
     SUSE,
     /// Ubuntu (<https://en.wikipedia.org/wiki/Ubuntu_(operating_system)>).
     Ubuntu,
-    /// Unknown operating system.
-    Unknown,
     /// Windows (<https://en.wikipedia.org/wiki/Microsoft_Windows>).
     Windows,
 }


### PR DESCRIPTION
I want to use u8 to record what system it is, enum can be as u8 . Unknown is placed first, and it will be the number 0. I think it is appropriate to use 0 to identify unknown systems.
In addition, I hope that when additional operating systems are added in the future, the ordering of the existing systems in the enum will not be changed.

<!--
Please describe the pull request motivation and changes here along with non-obvious things.
-->
