### PR TITLE
Add detection of Gentoo Linux

### DIFF
--- a/os_info/src/linux/lsb_release.rs
+++ b/os_info/src/linux/lsb_release.rs
@@ -22,6 +22,7 @@ pub fn get() -> Option<Info> {
         Some("Debian") => Type::Debian,
         Some("EndeavourOS") => Type::EndeavourOS,
         Some("Fedora") | Some("Fedora Linux") => Type::Fedora,
+        Some("Gentoo") => Type::Gentoo,
         Some("Linuxmint") => Type::Mint,
         Some("ManjaroLinux") => Type::Manjaro,
         Some("Mariner") => Type::Mariner,

--- a/os_info/src/os_type.rs
+++ b/os_info/src/os_type.rs
@@ -28,6 +28,8 @@ pub enum Type {
     Fedora,
     /// FreeBSD (<https://en.wikipedia.org/wiki/FreeBSD>).
     FreeBSD,
+    /// Gentoo Linux (<https://en.wikipedia.org/wiki/Gentoo_Linux>).
+    Gentoo,
     /// Linux based operating system (<https://en.wikipedia.org/wiki/Linux>).
     HardenedBSD,
     /// HardenedBSD (https://hardenedbsd.org/)


### PR DESCRIPTION
Tested on a gentoo machine.

Old output (from latest `cargo install os_info_cli`):
```
$ os_info 
OS information:
Type: Linux
Version: 2.7
Bitness: 64-bit
```

New output (from `cargo run` in `/cli` in this change):
```
/cli$ cargo run 
   Compiling os_info v3.3.0 (/home/matt/src/os_info/os_info)
   Compiling os_info_cli v2.0.0 (/home/matt/src/os_info/cli)
    Finished dev [unoptimized + debuginfo] target(s) in 4.44s
     Running `/home/matt/src/os_info/target/debug/os_info`
OS information:
Type: Gentoo
Version: 2.7
Bitness: 64-bit
```