### PR TITLE
Fix #308: Behavior break on FreeBSD to return Type::Unknown

### DIFF
--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -37,7 +37,7 @@ fn get_os() -> Type {
                 .expect("Failed to check if is hardened");
             match str::from_utf8(&check_hardening.stderr) {
                 Ok("0\n") => Type::HardenedBSD,
-                Ok(_) => Type::Unknown,
+                Ok(_) => Type::FreeBSD,
                 Err(_) => Type::FreeBSD,
             }
         }


### PR DESCRIPTION
As per issue #308, If I remember correctly, old behavior would hit the error case on FreeBSD. Best I can guess is that behavior has changed on FreeBSD's end that doesn't trigger the `Err(_)` case in the matching and triggers now the `Ok(_)` arm. So I now have the `Ok(_)` arm returning `Type::FreeBSD` instead of `Type::Unknown.` Tested on FreeBSD 13.0-Release-p11.
