### PR TITLE
Improve RHEL detection in /etc/os-release

### DIFF
--- a/os_info/src/linux/tests/os-release-rhel-7
+++ b/os_info/src/linux/tests/os-release-rhel-7
@@ -1,0 +1,17 @@
+NAME="Red Hat Enterprise Linux Server"
+VERSION="7.9 (Maipo)"
+ID="rhel"
+ID_LIKE="fedora"
+VARIANT="Server"
+VARIANT_ID="server"
+VERSION_ID="7.9"
+PRETTY_NAME="Red Hat Enterprise Linux Server 7.9 (Maipo)"
+ANSI_COLOR="0;31"
+CPE_NAME="cpe:/o:redhat:enterprise_linux:7.9:GA:server"
+HOME_URL="https://www.redhat.com/"
+BUG_REPORT_URL="https://bugzilla.redhat.com/"
+
+REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 7"
+REDHAT_BUGZILLA_PRODUCT_VERSION=7.9
+REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
+REDHAT_SUPPORT_PRODUCT_VERSION="7.9"


### PR DESCRIPTION
First, this changes to `Type::RedHatEnterprise`, just as the `lsb_release` detection does.

Second, this matches the name string as a prefix, because RHEL7 and earlier also had a variant suffix like "Server".