### PR TITLE
Implement OS Family feature

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -37,10 +37,11 @@ fn main() {
         }
 
         println!(
-            "OS information:\nType: {}\nVersion: {}\nBitness: {}",
+            "OS information:\nType: {}\nVersion: {}\nBitness: {}\nFamily: {}",
             info.os_type(),
             info.version(),
-            info.bitness()
+            info.bitness(),
+            info.family(),
         );
     } else {
         if options.type_ {

--- a/os_info/src/android/mod.rs
+++ b/os_info/src/android/mod.rs
@@ -1,11 +1,12 @@
 use log::trace;
 
-use crate::{Bitness, Info, Type};
+use crate::{Bitness, Info, Type, Family};
 
 pub fn current_platform() -> Info {
     trace!("android::current_platform is called");
 
     let info = Info::with_type(Type::Android);
+    info.family = Family::Linux;
     trace!("Returning {:?}", info);
     info
 }

--- a/os_info/src/dragonfly/mod.rs
+++ b/os_info/src/dragonfly/mod.rs
@@ -2,7 +2,7 @@ use std::process::Command;
 
 use log::trace;
 
-use crate::{bitness, uname::uname, Bitness, Info, Type, Version};
+use crate::{bitness, uname::uname, Bitness, Info, Type, Version, Family};
 
 pub fn current_platform() -> Info {
     trace!("dragonfly::current_platform is called");
@@ -15,6 +15,7 @@ pub fn current_platform() -> Info {
         os_type: Type::DragonFly,
         version,
         bitness: bitness::get(),
+        family: Family::BSD,
         ..Default::default()
     };
 

--- a/os_info/src/family.rs
+++ b/os_info/src/family.rs
@@ -1,0 +1,47 @@
+use std::fmt::{self, Display, Formatter};
+
+/// A general category for operating system to place them into 'families'
+/// Example of use case is when program logic needs to perform an operation
+/// on linux, but doesnt care which distro it is.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[allow(non_camel_case_types, clippy::upper_case_acronyms)]
+#[non_exhaustive]
+pub enum Family {
+    /// Berkely Standard Distributions
+    /// https://en.wikipedia.org/wiki/Berkeley_Software_Distribution
+    BSD,
+    /// Linux Operating systems of all type
+    /// https://en.wikipedia.org/wiki/Linux
+    Linux,
+    /// Apple's MacOS
+    /// https://en.wikipedia.org/wiki/Macintosh_operating_systems
+    MacOS,
+    /// SunOS and OSs derived from SunOS such as Illumos
+    /// https://en.wikipedia.org/wiki/SunOS
+    SunOS,
+    /// Operating systems whose family is unknown
+    Unknown,
+    /// Operating systems that are DOS or derived from DOS
+    /// https://en.wikipedia.org/wiki/Disk_operating_system
+    DOS,
+}
+
+impl Default for Family {
+    fn default() -> Self {
+	Family::Unknown
+    }
+}
+
+impl Display for Family {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+	match *self {
+	    Family::BSD => write!(f, "BSD"),
+	    Family::Linux => write!(f, "Linux"),
+	    Family::MacOS => write!(f, "MacOS"),
+	    Family::SunOS => write!(f, "SunOS"),
+	    Family::DOS => write!(f, "DOS"),
+	    _ => write!(f, "{:?}", self),
+	}
+    }
+}

--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -3,7 +3,7 @@ use std::str;
 
 use log::{error, trace};
 
-use crate::{bitness, uname::uname, Info, Type, Version};
+use crate::{bitness, uname::uname, Info, Type, Version, Family};
 
 pub fn current_platform() -> Info {
     trace!("freebsd::current_platform is called");
@@ -16,6 +16,7 @@ pub fn current_platform() -> Info {
         os_type: get_os(),
         version,
         bitness: bitness::get(),
+	family: Family::BSD,
         ..Default::default()
     };
 

--- a/os_info/src/illumos/mod.rs
+++ b/os_info/src/illumos/mod.rs
@@ -3,7 +3,7 @@ use std::str;
 
 use log::{error, trace};
 
-use crate::{bitness, uname::uname, Info, Type, Version};
+use crate::{bitness, uname::uname, Info, Type, Version, Family};
 
 pub fn current_platform() -> Info {
     trace!("illumos::current_platform is called");
@@ -16,6 +16,7 @@ pub fn current_platform() -> Info {
         os_type: get_os(),
         version,
         bitness: bitness::get(),
+        family: Family::SunOS,
         ..Default::default()
     };
 

--- a/os_info/src/info.rs
+++ b/os_info/src/info.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::{self, Display, Formatter};
 
-use super::{Bitness, Type, Version};
+use super::{Bitness, Type, Version, Family};
 
 /// Holds information about operating system (type, version, etc.).
 ///
@@ -31,6 +31,8 @@ pub struct Info {
     /// Operating system architecture in terms of how many bits compose the basic values it can deal
     /// with. See `Bitness` for details.
     pub(crate) bitness: Bitness,
+    /// Get the family of operating system. See "Family" for details.
+    pub(crate) family: Family,
 }
 
 impl Info {
@@ -55,6 +57,7 @@ impl Info {
             edition: None,
             codename: None,
             bitness: Bitness::Unknown,
+	        family: Family::Unknown,
         }
     }
 
@@ -147,6 +150,21 @@ impl Info {
     pub fn bitness(&self) -> Bitness {
         self.bitness
     }
+
+    /// Returns the operating system family. See 'Family' for details.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// use os_info::{Info, Family};
+    /// 
+    /// let info = Info::unknown();
+    /// assert_eq!(Family::Unknown, info.family());
+    /// ```
+    pub fn family(&self) -> Family {
+        self.family
+    }
+
 }
 
 impl Default for Info {
@@ -299,6 +317,7 @@ mod tests {
                     edition: Some("edition".to_owned()),
                     codename: Some("codename".to_owned()),
                     bitness: Bitness::X64,
+                    family: Family::MacOS,
                 },
                 "Mac OS 10.2.0 (edition) (codename) [64-bit]",
             ),

--- a/os_info/src/lib.rs
+++ b/os_info/src/lib.rs
@@ -72,6 +72,7 @@ mod imp;
 
 mod bitness;
 mod info;
+mod family;
 #[cfg(not(windows))]
 mod matcher;
 mod os_type;
@@ -85,7 +86,7 @@ mod os_type;
 mod uname;
 mod version;
 
-pub use crate::{bitness::Bitness, info::Info, os_type::Type, version::Version};
+pub use crate::{bitness::Bitness, info::Info, os_type::Type, version::Version, family::Family};
 
 /// Returns information about the current operating system (type, version, edition, etc.).
 ///

--- a/os_info/src/linux/mod.rs
+++ b/os_info/src/linux/mod.rs
@@ -3,7 +3,7 @@ mod lsb_release;
 
 use log::trace;
 
-use crate::{bitness, Info, Type};
+use crate::{bitness, Info, Type, Fmaily};
 
 pub fn current_platform() -> Info {
     trace!("linux::current_platform is called");
@@ -12,6 +12,7 @@ pub fn current_platform() -> Info {
         .or_else(file_release::get)
         .unwrap_or_else(|| Info::with_type(Type::Linux));
     info.bitness = bitness::get();
+    info.family = Family::Linux;
 
     trace!("Returning {:?}", info);
     info

--- a/os_info/src/macos/mod.rs
+++ b/os_info/src/macos/mod.rs
@@ -2,7 +2,7 @@ use std::process::Command;
 
 use log::{trace, warn};
 
-use crate::{bitness, matcher::Matcher, Info, Type, Version};
+use crate::{bitness, matcher::Matcher, Info, Type, Version, Family};
 
 pub fn current_platform() -> Info {
     trace!("macos::current_platform is called");
@@ -11,6 +11,7 @@ pub fn current_platform() -> Info {
         os_type: Type::Macos,
         version: version(),
         bitness: bitness::get(),
+        family: Family::MacOS,
         ..Default::default()
     };
     trace!("Returning {:?}", info);

--- a/os_info/src/netbsd/mod.rs
+++ b/os_info/src/netbsd/mod.rs
@@ -2,7 +2,7 @@ use std::process::Command;
 
 use log::{error, trace};
 
-use crate::{bitness, uname::uname, Info, Type, Version};
+use crate::{bitness, uname::uname, Info, Type, Version, Family};
 
 pub fn current_platform() -> Info {
     trace!("netbsd::current_platform is called");
@@ -15,6 +15,7 @@ pub fn current_platform() -> Info {
         os_type: Type::NetBSD,
         version,
         bitness: bitness::get(),
+	family: Family::BSD,
         ..Default::default()
     };
 

--- a/os_info/src/openbsd/mod.rs
+++ b/os_info/src/openbsd/mod.rs
@@ -2,7 +2,7 @@ use std::process::Command;
 
 use log::{error, trace};
 
-use crate::{bitness, uname::uname, Info, Type, Version};
+use crate::{bitness, uname::uname, Info, Type, Version, Fmaily};
 
 pub fn current_platform() -> Info {
     trace!("openbsd::current_platform is called");
@@ -15,6 +15,7 @@ pub fn current_platform() -> Info {
         os_type: Type::OpenBSD,
         version,
         bitness: bitness::get(),
+	family: Family::BSD,
         ..Default::default()
     };
 

--- a/os_info/src/redox/mod.rs
+++ b/os_info/src/redox/mod.rs
@@ -4,7 +4,7 @@ use std::{fs::File, io::Read};
 
 use log::{error, trace};
 
-use crate::{Bitness, Info, Type, Version};
+use crate::{Bitness, Info, Type, Version, Family};
 
 const UNAME_FILE: &str = "sys:uname";
 
@@ -18,6 +18,7 @@ pub fn current_platform() -> Info {
         os_type: Type::Redox,
         version,
         bitness: Bitness::Unknown,
+        family: Family::DOS,
         ..Default::default()
     };
     trace!("Returning {:?}", info);

--- a/os_info/src/windows/mod.rs
+++ b/os_info/src/windows/mod.rs
@@ -2,11 +2,12 @@ mod winapi;
 
 use log::trace;
 
-use crate::Info;
+use crate::{Info, Family};
 
 pub fn current_platform() -> Info {
     trace!("windows::current_platform is called");
     let info = winapi::get();
+    info.family = Family::DOS;
     trace!("Returning {:?}", info);
     info
 }


### PR DESCRIPTION
As per #312, this is adding a feature to display the family that an OS belongs to. Purpose is that in the case of Linux, if a caller of the library needs to perform program logic and it doesn't care what distro it is, it can use this to match against rather than match against every distribution listed in `Type.rs`.

The addition should not break any existing use of the API, only adds to the API.