### PR TITLE
Fix typo, explictly -> explicitly

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -66,7 +66,7 @@ ignore = [
 [licenses]
 # The lint level for crates which do not have a detectable license
 unlicensed = "deny"
-# List of explictly allowed licenses
+# List of explicitly allowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.7 short identifier (+ optional exception)].
 allow = [
@@ -74,7 +74,7 @@ allow = [
     "Apache-2.0",
     "Unicode-DFS-2016",
 ]
-# List of explictly disallowed licenses
+# List of explicitly disallowed licenses
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.7 short identifier (+ optional exception)].
 deny = [


### PR DESCRIPTION
Found via `typos --format brief`

<!--
Please describe the pull request motivation and changes here along with non-obvious things.
-->
