### PR TITLE
add os-release match for Arch and Debian ARM

### DIFF
--- a/os_info/src/linux/file_release.rs
+++ b/os_info/src/linux/file_release.rs
@@ -96,13 +96,14 @@ static DISTRIBUTIONS: [ReleaseInfo; 6] = [
                     //"antergos" => Antergos
                     //"aosc" => AOSC
                     "arch" => Some(Type::Arch),
+                    "archarm" => Some(Type::Arch),
                     //"artix" => Artix
                     "centos" => Some(Type::CentOS),
                     //"clear-linux-os" => ClearLinuxOS
                     //"clearos" => ClearOS
                     //"coreos"
                     //"cumulus-linux" => Cumulus
-                    //"debian" => Debian
+                    "debian" => Some(Type::Debian),
                     //"devuan" => Devuan
                     //"elementary" => Elementary
                     "fedora" => Some(Type::Fedora),
@@ -242,6 +243,28 @@ mod tests {
     }
 
     #[test]
+    fn arch_os_release() {
+        let root = "src/linux/tests/Arch";
+
+        let info = retrieve(&DISTRIBUTIONS, root).unwrap();
+        assert_eq!(info.os_type(), Type::Arch);
+        assert_eq!(info.version, Version::Unknown);
+        assert_eq!(info.edition, None);
+        assert_eq!(info.codename, None);
+    }
+
+    #[test]
+    fn archarm_os_release() {
+        let root = "src/linux/tests/ArchARM";
+
+        let info = retrieve(&DISTRIBUTIONS, root).unwrap();
+        assert_eq!(info.os_type(), Type::Arch);
+        assert_eq!(info.version, Version::Unknown);
+        assert_eq!(info.edition, None);
+        assert_eq!(info.codename, None);
+    }
+
+    #[test]
     fn centos_7_os_release() {
         let root = "src/linux/tests/CentOS_7";
 
@@ -281,6 +304,17 @@ mod tests {
         let info = retrieve(&DISTRIBUTIONS, root).unwrap();
         assert_eq!(info.os_type(), Type::CentOS);
         assert_eq!(info.version, Version::Unknown);
+        assert_eq!(info.edition, None);
+        assert_eq!(info.codename, None);
+    }
+
+    #[test]
+    fn debian_11_os_release() {
+        let root = "src/linux/tests/Debian_11";
+
+        let info = retrieve(&DISTRIBUTIONS, root).unwrap();
+        assert_eq!(info.os_type(), Type::Debian);
+        assert_eq!(info.version, Version::Semantic(11, 0, 0));
         assert_eq!(info.edition, None);
         assert_eq!(info.codename, None);
     }

--- a/os_info/src/linux/tests/Arch/etc/os-release
+++ b/os_info/src/linux/tests/Arch/etc/os-release
@@ -1,0 +1,11 @@
+NAME="Arch Linux"
+PRETTY_NAME="Arch Linux"
+ID=arch
+BUILD_ID=rolling
+ANSI_COLOR="38;2;23;147;209"
+HOME_URL="https://archlinux.org/"
+DOCUMENTATION_URL="https://wiki.archlinux.org/"
+SUPPORT_URL="https://bbs.archlinux.org/"
+BUG_REPORT_URL="https://bugs.archlinux.org/"
+PRIVACY_POLICY_URL="https://terms.archlinux.org/docs/privacy-policy/"
+LOGO=archlinux-logo

--- a/os_info/src/linux/tests/ArchARM/etc/os-release
+++ b/os_info/src/linux/tests/ArchARM/etc/os-release
@@ -1,0 +1,11 @@
+NAME="Arch Linux ARM"
+PRETTY_NAME="Arch Linux ARM"
+ID=archarm
+ID_LIKE=arch
+BUILD_ID=rolling
+ANSI_COLOR="38;2;23;147;209"
+HOME_URL="https://archlinuxarm.org/"
+DOCUMENTATION_URL="https://archlinuxarm.org/wiki"
+SUPPORT_URL="https://archlinuxarm.org/forum"
+BUG_REPORT_URL="https://github.com/archlinuxarm/PKGBUILDs/issues"
+LOGO=archlinux-logo

--- a/os_info/src/linux/tests/Debian_11/etc/os-release
+++ b/os_info/src/linux/tests/Debian_11/etc/os-release
@@ -1,0 +1,9 @@
+PRETTY_NAME="Debian GNU/Linux 11 (bullseye)"
+NAME="Debian GNU/Linux"
+VERSION_ID="11"
+VERSION="11 (bullseye)"
+VERSION_CODENAME=bullseye
+ID=debian
+HOME_URL="https://www.debian.org/"
+SUPPORT_URL="https://www.debian.org/support"
+BUG_REPORT_URL="https://bugs.debian.org/"


### PR DESCRIPTION
Arch ARM does not include lsb_release by default, and had no fallback setup yet for os-release.

Debian ARM does include lsb_release on Raspberry Pi version, but that may not be universal.