### PR TITLE
335 issue add processor architecture informations

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ println!("OS information: {info}");
 println!("Type: {}", info.os_type());
 println!("Version: {}", info.version());
 println!("Bitness: {}", info.bitness());
+println!("Architecture: {}", info.architecture());
 ```
 
 ### Command line tool (`os_info_cli`)

--- a/os_info/examples/print_version.rs
+++ b/os_info/examples/print_version.rs
@@ -10,4 +10,5 @@ fn main() {
     println!("Edition: {:?}", info.edition());
     println!("Codename: {:?}", info.codename());
     println!("Bitness: {}", info.bitness());
+    println!("Architecture: {:?}", info.architecture());
 }

--- a/os_info/src/architecture.rs
+++ b/os_info/src/architecture.rs
@@ -1,0 +1,32 @@
+use std::process::Command;
+
+use log::error;
+
+pub fn architecture() -> Option<String> {
+    Command::new("uname")
+        .arg("-m")
+        .output()
+        .map_err(|e| {
+            error!("Cannot invoke 'uname` to get architecture type: {:?}", e);
+        })
+        .ok()
+        .and_then(|out| {
+            if out.status.success() {
+                Some(String::from_utf8_lossy(&out.stdout).trim_end().to_owned())
+            } else {
+                log::error!("'uname' invocation error: {:?}", out);
+                None
+            }
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uname_nonempty() {
+        let val = architecture().expect("uname failed");
+        assert!(!val.is_empty());
+    }
+}

--- a/os_info/src/info.rs
+++ b/os_info/src/info.rs
@@ -31,6 +31,8 @@ pub struct Info {
     /// Operating system architecture in terms of how many bits compose the basic values it can deal
     /// with. See `Bitness` for details.
     pub(crate) bitness: Bitness,
+    // Processor architecture.
+    pub(crate) architecture: Option<String>,
 }
 
 impl Info {
@@ -47,6 +49,7 @@ impl Info {
     /// assert_eq!(None, info.edition());
     /// assert_eq!(None, info.codename());
     /// assert_eq!(Bitness::Unknown, info.bitness());
+    /// assert_eq!(None, info.architecture());
     /// ```
     pub fn unknown() -> Self {
         Self {
@@ -55,6 +58,7 @@ impl Info {
             edition: None,
             codename: None,
             bitness: Bitness::Unknown,
+            architecture: None,
         }
     }
 
@@ -72,6 +76,7 @@ impl Info {
     /// assert_eq!(None, info.edition());
     /// assert_eq!(None, info.codename());
     /// assert_eq!(Bitness::Unknown, info.bitness());
+    /// assert_eq!(None, info.architecture());
     /// ```
     pub fn with_type(os_type: Type) -> Self {
         Self {
@@ -147,6 +152,19 @@ impl Info {
     pub fn bitness(&self) -> Bitness {
         self.bitness
     }
+
+    /// Returns operating system architecture.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use os_info::Info;
+    ///
+    /// let info = Info::unknown();
+    /// assert_eq!(None, info.architecture());
+    pub fn architecture(&self) -> Option<&str> {
+        self.architecture.as_ref().map(String::as_ref)
+    }
 }
 
 impl Default for Info {
@@ -184,6 +202,7 @@ mod tests {
         assert_eq!(None, info.edition());
         assert_eq!(None, info.codename());
         assert_eq!(Bitness::Unknown, info.bitness());
+        assert_eq!(None, info.architecture());
     }
 
     #[test]
@@ -301,6 +320,7 @@ mod tests {
                     edition: Some("edition".to_owned()),
                     codename: Some("codename".to_owned()),
                     bitness: Bitness::X64,
+                    architecture: Some("architecture".to_owned()),
                 },
                 "Mac OS 10.2.0 (edition) (codename) [64-bit]",
             ),

--- a/os_info/src/info.rs
+++ b/os_info/src/info.rs
@@ -26,7 +26,7 @@ pub struct Info {
     pub(crate) version: Version,
     /// Operating system edition.
     pub(crate) edition: Option<String>,
-    /// Operating system edition.
+    /// Operating system codename.
     pub(crate) codename: Option<String>,
     /// Operating system architecture in terms of how many bits compose the basic values it can deal
     /// with. See `Bitness` for details.

--- a/os_info/src/lib.rs
+++ b/os_info/src/lib.rs
@@ -70,6 +70,7 @@ mod imp;
 #[path = "unknown/mod.rs"]
 mod imp;
 
+mod architecture;
 mod bitness;
 mod info;
 #[cfg(not(windows))]
@@ -105,6 +106,7 @@ pub use crate::{bitness::Bitness, info::Info, os_type::Type, version::Version};
 /// println!("Edition: {:?}", info.edition());
 /// println!("Codename: {:?}", info.codename());
 /// println!("Bitness: {}", info.bitness());
+/// println!("Architecture: {:?}", info.architecture());
 /// ```
 pub fn get() -> Info {
     imp::current_platform()

--- a/os_info/src/linux/mod.rs
+++ b/os_info/src/linux/mod.rs
@@ -3,7 +3,7 @@ mod lsb_release;
 
 use log::trace;
 
-use crate::{bitness, Info, Type};
+use crate::{architecture, bitness, Info, Type};
 
 pub fn current_platform() -> Info {
     trace!("linux::current_platform is called");
@@ -12,6 +12,7 @@ pub fn current_platform() -> Info {
         .or_else(file_release::get)
         .unwrap_or_else(|| Info::with_type(Type::Linux));
     info.bitness = bitness::get();
+    info.architecture = architecture::architecture();
 
     trace!("Returning {:?}", info);
     info

--- a/os_info/src/macos/mod.rs
+++ b/os_info/src/macos/mod.rs
@@ -2,7 +2,7 @@ use std::process::Command;
 
 use log::{trace, warn};
 
-use crate::{bitness, matcher::Matcher, Info, Type, Version};
+use crate::{architecture::architecture, bitness, matcher::Matcher, Info, Type, Version};
 
 pub fn current_platform() -> Info {
     trace!("macos::current_platform is called");
@@ -11,6 +11,7 @@ pub fn current_platform() -> Info {
         os_type: Type::Macos,
         version: version(),
         bitness: bitness::get(),
+        architecture: architecture(),
         ..Default::default()
     };
     trace!("Returning {:?}", info);

--- a/os_info/src/netbsd/mod.rs
+++ b/os_info/src/netbsd/mod.rs
@@ -2,7 +2,7 @@ use std::process::Command;
 
 use log::{error, trace};
 
-use crate::{bitness, uname::uname, Info, Type, Version};
+use crate::{architecture::architecture, bitness, uname::uname, Info, Type, Version};
 
 pub fn current_platform() -> Info {
     trace!("netbsd::current_platform is called");
@@ -15,6 +15,7 @@ pub fn current_platform() -> Info {
         os_type: Type::NetBSD,
         version,
         bitness: bitness::get(),
+        architecture: architecture::architecture(),
         ..Default::default()
     };
 

--- a/os_info/src/openbsd/mod.rs
+++ b/os_info/src/openbsd/mod.rs
@@ -2,7 +2,7 @@ use std::process::Command;
 
 use log::{error, trace};
 
-use crate::{bitness, uname::uname, Info, Type, Version};
+use crate::{architecture::architecture, bitness, uname::uname, Info, Type, Version};
 
 pub fn current_platform() -> Info {
     trace!("openbsd::current_platform is called");
@@ -15,6 +15,7 @@ pub fn current_platform() -> Info {
         os_type: Type::OpenBSD,
         version,
         bitness: bitness::get(),
+        architecture: architecture::architecture(),
         ..Default::default()
     };
 


### PR DESCRIPTION
Processor architecture is also useful information. Would be nice to have it as part of Info. _As I described in issue #335._

To get processor architecture I used the command `uname -m` which is working on all (_as far I know_) Unix/Linux based systems, that is also the reason why I've added it just into those systems.
I intentionally didn't change the method `Info.display()`, since I'm not sure whether it is worth doing it and also may break some scripts build on top of it.