### PR TITLE
Add support for Mabox, resolves #337

### DIFF
--- a/os_info/src/linux/lsb_release.rs
+++ b/os_info/src/linux/lsb_release.rs
@@ -25,6 +25,7 @@ pub fn get() -> Option<Info> {
         Some("Garuda") => Type::Garuda,
         Some("Gentoo") => Type::Gentoo,
         Some("Linuxmint") => Type::Mint,
+        Some("MaboxLinux") => Type::Mabox,
         Some("ManjaroLinux") => Type::Manjaro,
         Some("Mariner") => Type::Mariner,
         Some("NixOS") => Type::NixOS,

--- a/os_info/src/linux/mod.rs
+++ b/os_info/src/linux/mod.rs
@@ -35,6 +35,7 @@ mod tests {
             | Type::Garuda
             | Type::Gentoo
             | Type::Linux
+            | Type::Mabox
             | Type::Manjaro
             | Type::Mariner
             | Type::NixOS

--- a/os_info/src/os_type.rs
+++ b/os_info/src/os_type.rs
@@ -38,6 +38,8 @@ pub enum Type {
     Illumos,
     /// Linux based operating system (<https://en.wikipedia.org/wiki/Linux>).
     Linux,
+    /// Mabox (<https://maboxlinux.org/>).
+    Mabox,
     /// Mac OS X/OS X/macOS (<https://en.wikipedia.org/wiki/MacOS>).
     Macos,
     /// Manjaro (<https://en.wikipedia.org/wiki/Manjaro>).


### PR DESCRIPTION
Doing this because I want Starship command prompt to show something other than just Tux on my Mabox system. I couldn't find a Wikipedia article for Mabox, so I put a link to Mabox's own website in the comment in os_type.rs.