### PR TITLE
Add Alpaquita Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ os_info --help
 
 Right now, the following operating system types can be returned:
 
+- Alpaquita Linux
 - Alpine Linux
 - Amazon Linux AMI
 - Android

--- a/os_info/src/info.rs
+++ b/os_info/src/info.rs
@@ -209,6 +209,7 @@ mod tests {
     fn with_type() {
         let types = [
             Type::Redox,
+            Type::Alpaquita,
             Type::Alpine,
             Type::Amazon,
             Type::Android,

--- a/os_info/src/linux/file_release.rs
+++ b/os_info/src/linux/file_release.rs
@@ -91,6 +91,7 @@ static DISTRIBUTIONS: [ReleaseInfo; 6] = [
                     // https://github.com/chef/os_release
 
                     //"almalinux" => Alma
+                    "alpaquita" => Some(Type::Alpaquita),
                     "alpine" => Some(Type::Alpine),
                     "amzn" => Some(Type::Amazon),
                     //"antergos" => Antergos
@@ -197,6 +198,17 @@ static DISTRIBUTIONS: [ReleaseInfo; 6] = [
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
+
+    #[test]
+    fn alpaquita_os_release() {
+        let root = "src/linux/tests/Alpaquita";
+
+        let info = retrieve(&DISTRIBUTIONS, root).unwrap();
+        assert_eq!(info.os_type(), Type::Alpaquita);
+        assert_eq!(info.version, Version::Semantic(23, 0, 0));
+        assert_eq!(info.edition, None);
+        assert_eq!(info.codename, None);
+    }
 
     #[test]
     fn alpine_3_12_os_release() {

--- a/os_info/src/linux/lsb_release.rs
+++ b/os_info/src/linux/lsb_release.rs
@@ -16,6 +16,7 @@ pub fn get() -> Option<Info> {
     };
 
     let os_type = match release.distribution.as_ref().map(String::as_ref) {
+        Some("Alpaquita") => Type::Alpaquita,
         Some("Amazon") | Some("AmazonAMI") => Type::Amazon,
         Some("Arch") => Type::Arch,
         Some("CentOS") => Type::CentOS,
@@ -109,6 +110,14 @@ mod tests {
         assert_eq!(parse_results.distribution, Some("Debian".to_string()));
         assert_eq!(parse_results.version, Some("7.8".to_string()));
         assert_eq!(parse_results.codename, Some("wheezy".to_string()));
+    }
+
+    #[test]
+    fn alpaquita() {
+        let parse_results = parse(alpaquita_file());
+        assert_eq!(parse_results.distribution, Some("Alpaquita".to_string()));
+        assert_eq!(parse_results.version, Some("23".to_string()));
+        assert_eq!(parse_results.codename, None);
     }
 
     #[test]
@@ -297,6 +306,13 @@ mod tests {
          Release:	7.8\n\
          Codename:	wheezy\n\
          "
+    }
+
+    fn alpaquita_file() -> &'static str {
+        "\nDistributor ID: Alpaquita\n\
+        Description:    BellSoft Alpaquita Linux Stream 23 (musl)\n\
+        Release:        23\n\
+        Codename:       n/a"
     }
 
     fn arch_file() -> &'static str {

--- a/os_info/src/linux/mod.rs
+++ b/os_info/src/linux/mod.rs
@@ -26,7 +26,8 @@ mod tests {
     fn os_type() {
         let version = current_platform();
         match version.os_type() {
-            Type::Alpine
+            Type::Alpaquita
+            | Type::Alpine
             | Type::Amazon
             | Type::Arch
             | Type::CentOS

--- a/os_info/src/linux/tests/Alpaquita/etc/os-release
+++ b/os_info/src/linux/tests/Alpaquita/etc/os-release
@@ -1,0 +1,8 @@
+NAME="BellSoft Alpaquita Linux Stream"
+ID=alpaquita
+ID_LIKE=alpine
+VERSION_ID=23
+PRETTY_NAME="BellSoft Alpaquita Linux Stream 23 (musl)"
+HOME_URL="https://bell-sw.com/"
+BUG_REPORT_URL="https://bell-sw.com/support/"
+LIBC_TYPE=musl

--- a/os_info/src/os_type.rs
+++ b/os_info/src/os_type.rs
@@ -6,6 +6,8 @@ use std::fmt::{self, Display, Formatter};
 #[allow(non_camel_case_types, clippy::upper_case_acronyms)]
 #[non_exhaustive]
 pub enum Type {
+    /// Alpaquita Linux (<https://bell-sw.com/alpaquita-linux/>).
+    Alpaquita,
     /// Alpine Linux (<https://en.wikipedia.org/wiki/Alpine_Linux>).
     Alpine,
     /// Amazon Linux AMI (<https://en.wikipedia.org/wiki/Amazon_Machine_Image#Amazon_Linux_AMI>).
@@ -95,6 +97,7 @@ impl Default for Type {
 impl Display for Type {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         match *self {
+            Type::Alpaquita => write!(f, "Alpaquita Linux"),
             Type::Alpine => write!(f, "Alpine Linux"),
             Type::Amazon => write!(f, "Amazon Linux AMI"),
             Type::Arch => write!(f, "Arch Linux"),
@@ -127,6 +130,7 @@ mod tests {
     #[test]
     fn display() {
         let data = [
+            (Type::Alpaquita, "Alpaquita Linux"),
             (Type::Alpine, "Alpine Linux"),
             (Type::Amazon, "Amazon Linux AMI"),
             (Type::Android, "Android"),


### PR DESCRIPTION
The main motivation is to make `cargo -vV` report the correct distro name.


The distro does not ship LSB utils, so the LSB code path was tested with a manually built version of lsb-release-minimal from https://salsa.debian.org/gioele/lsb-release-minimal

Thanks.

<!--
Please describe the pull request motivation and changes here along with non-obvious things.
-->
