### PR TITLE
deps: Move from winapi to windows-sys

### DIFF
--- a/os_info/Cargo.toml
+++ b/os_info/Cargo.toml
@@ -21,7 +21,15 @@ log = "0.4.5"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3.8", features = ["minwindef", "ntdef", "ntstatus", "sysinfoapi", "winnt", "winuser", "libloaderapi", "processthreadsapi", "winerror", "winreg"] }
+windows-sys = { version = "0.45", features = [
+    "Win32_Foundation",
+    "Win32_System_Diagnostics_Debug",
+    "Win32_System_LibraryLoader",
+    "Win32_System_SystemInformation",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_System_Registry",
+    "Win32_System_SystemServices",
+]}
 
 [dev-dependencies]
 pretty_assertions = "1"


### PR DESCRIPTION
<!--
Please describe the pull request motivation and changes here along with non-obvious things.
-->
`winapi` is in maintenance mode and the new blessed way to access Windows APIs are the `windows`
and `windows-sys` crates. I don't think any types of `winapi` were exposed in the public API so
I used `windows-sys` since it has much faster compile times.