### PR TITLE
Add support for Artix Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Right now, the following operating system types can be returned:
 - Amazon Linux AMI
 - Android
 - Arch Linux
+- Artix Linux
 - CentOS
 - Debian
 - DragonFly BSD

--- a/os_info/src/info.rs
+++ b/os_info/src/info.rs
@@ -213,6 +213,7 @@ mod tests {
             Type::Amazon,
             Type::Android,
             Type::Arch,
+            Type::Artix,
             Type::CentOS,
             Type::Debian,
             Type::Emscripten,
@@ -280,6 +281,14 @@ mod tests {
                     ..Default::default()
                 },
                 "Arch Linux Rolling Release [unknown bitness]",
+            ),
+            (
+                Info {
+                    os_type: Type::Artix,
+                    version: Version::Rolling(None),
+                    ..Default::default()
+                },
+                "Artix Linux Rolling Release [unknown bitness]",
             ),
             (
                 Info {

--- a/os_info/src/linux/file_release.rs
+++ b/os_info/src/linux/file_release.rs
@@ -97,7 +97,7 @@ static DISTRIBUTIONS: [ReleaseInfo; 6] = [
                     //"aosc" => AOSC
                     "arch" => Some(Type::Arch),
                     "archarm" => Some(Type::Arch),
-                    //"artix" => Artix
+                    "artix" => Some(Type::Artix),
                     "centos" => Some(Type::CentOS),
                     //"clear-linux-os" => ClearLinuxOS
                     //"clearos" => ClearOS
@@ -259,6 +259,17 @@ mod tests {
 
         let info = retrieve(&DISTRIBUTIONS, root).unwrap();
         assert_eq!(info.os_type(), Type::Arch);
+        assert_eq!(info.version, Version::Unknown);
+        assert_eq!(info.edition, None);
+        assert_eq!(info.codename, None);
+    }
+
+    #[test]
+    fn artix_os_release() {
+        let root = "src/linux/tests/Artix";
+
+        let info = retrieve(&DISTRIBUTIONS, root).unwrap();
+        assert_eq!(info.os_type(), Type::Artix);
         assert_eq!(info.version, Version::Unknown);
         assert_eq!(info.edition, None);
         assert_eq!(info.codename, None);

--- a/os_info/src/linux/lsb_release.rs
+++ b/os_info/src/linux/lsb_release.rs
@@ -18,6 +18,7 @@ pub fn get() -> Option<Info> {
     let os_type = match release.distribution.as_ref().map(String::as_ref) {
         Some("Amazon") | Some("AmazonAMI") => Type::Amazon,
         Some("Arch") => Type::Arch,
+        Some("Artix") => Type::Artix,
         Some("CentOS") => Type::CentOS,
         Some("Debian") => Type::Debian,
         Some("EndeavourOS") => Type::EndeavourOS,
@@ -115,6 +116,14 @@ mod tests {
     fn arch() {
         let parse_results = parse(arch_file());
         assert_eq!(parse_results.distribution, Some("Arch".to_string()));
+        assert_eq!(parse_results.version, Some("rolling".to_string()));
+        assert_eq!(parse_results.codename, None);
+    }
+
+    #[test]
+    fn artix() {
+        let parse_results = parse(artix_file());
+        assert_eq!(parse_results.distribution, Some("Artix".to_string()));
         assert_eq!(parse_results.version, Some("rolling".to_string()));
         assert_eq!(parse_results.codename, None);
     }
@@ -303,6 +312,14 @@ mod tests {
         "\nLSB Version:	1.4\n\
          Distributor ID:	Arch\n\
          Description:	Arch Linux\n\
+         Release:	rolling\n\
+         Codename:	n/a"
+    }
+
+    fn artix_file() -> &'static str {
+        "\nLSB Version:	n/a\n\
+         Distributor ID:	Artix\n\
+         Description:	Artix Linux\n\
          Release:	rolling\n\
          Codename:	n/a"
     }

--- a/os_info/src/linux/mod.rs
+++ b/os_info/src/linux/mod.rs
@@ -29,6 +29,7 @@ mod tests {
             Type::Alpine
             | Type::Amazon
             | Type::Arch
+            | Type::Artix
             | Type::CentOS
             | Type::Debian
             | Type::EndeavourOS

--- a/os_info/src/linux/tests/Artix/etc/os-release
+++ b/os_info/src/linux/tests/Artix/etc/os-release
@@ -1,0 +1,9 @@
+NAME="Artix Linux"
+PRETTY_NAME="Artix Linux"
+ID=artix
+BUILD_ID=rolling
+ANSI_COLOR="38;2;23;147;209"
+HOME_URL="https://artixlinux.org/"
+DOCUMENTATION_URL="https://wiki.artixlinux.org/"
+SUPPORT_URL="https://forum.artixlinux.org/"
+BUG_REPORT_URL="https://gitea.artixlinux.org/artix"

--- a/os_info/src/os_type.rs
+++ b/os_info/src/os_type.rs
@@ -14,6 +14,8 @@ pub enum Type {
     Android,
     /// Arch Linux (<https://en.wikipedia.org/wiki/Arch_Linux>).
     Arch,
+    /// Artix Linux (<https://en.wikipedia.org/wiki/Artix_Linux>).
+    Artix,
     /// CentOS (<https://en.wikipedia.org/wiki/CentOS>).
     CentOS,
     /// Debian (<https://en.wikipedia.org/wiki/Debian>).
@@ -98,6 +100,7 @@ impl Display for Type {
             Type::Alpine => write!(f, "Alpine Linux"),
             Type::Amazon => write!(f, "Amazon Linux AMI"),
             Type::Arch => write!(f, "Arch Linux"),
+            Type::Artix => write!(f, "Artix Linux"),
             Type::DragonFly => write!(f, "DragonFly BSD"),
             Type::Garuda => write!(f, "Garuda Linux"),
             Type::Gentoo => write!(f, "Gentoo Linux"),
@@ -131,6 +134,7 @@ mod tests {
             (Type::Amazon, "Amazon Linux AMI"),
             (Type::Android, "Android"),
             (Type::Arch, "Arch Linux"),
+            (Type::Artix, "Artix Linux"),
             (Type::CentOS, "CentOS"),
             (Type::Debian, "Debian"),
             (Type::DragonFly, "DragonFly BSD"),


### PR DESCRIPTION
Added the ability to be able to detect Artix Linux.
With `lsb-release` installed the output is:
```
OS information:
Type: Artix Linux
Version: Rolling Release
Bitness: 64-bit
```
Without `lsb-release` installed the output is:
```
OS information:
Type: Artix Linux
Version: Unknown
Bitness: 64-bit
```
It is missing the version field. I don't know if this is normal or how to fix it.