### PR TITLE
Support AIX operating system

### DIFF
--- a/os_info/src/aix/mod.rs
+++ b/os_info/src/aix/mod.rs
@@ -1,0 +1,72 @@
+use std::process::Command;
+use std::str;
+
+use log::{error, trace};
+
+use crate::{bitness, uname::uname, Info, Type, Version};
+
+pub fn current_platform() -> Info {
+    trace!("aix::current_platform is called");
+
+    let version = get_version()
+        .map(Version::from_string)
+        .unwrap_or_else(|| Version::Unknown);
+
+    let info = Info {
+        os_type: get_os(),
+        version,
+        bitness: bitness::get(),
+        ..Default::default()
+    };
+
+    trace!("Returning {:?}", info);
+    info
+}
+
+fn get_version() -> Option<String> {
+    fn parse_uname(arg: &str) -> Option<String> {
+        Command::new("uname")
+            .arg(arg)
+            .output()
+            .map_err(|e| {
+                error!("Failed to invoke 'uname': {:?}", e);
+            })
+            .ok()
+            .and_then(|out| {
+                if out.status.success() {
+                    Some(String::from_utf8_lossy(&out.stdout).trim_end().to_owned())
+                } else {
+                    log::error!("'uname' invocation error: {:?}", out);
+                    None
+                }
+            })
+    }
+
+    let major = parse_uname("-v")?;
+    let minor = parse_uname("-r").unwrap_or(String::from("0"));
+    Some(format!("{}.{}", major, minor))
+}
+
+fn get_os() -> Type {
+    let os = Command::new("uname")
+        .arg("-o")
+        .output()
+        .expect("Failed to get OS");
+
+    match str::from_utf8(&os.stdout) {
+        Ok("AIX\n") => Type::AIX,
+        Ok(_) => Type::Unknown,
+        Err(_) => Type::Unknown,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn os_type() {
+        let version = current_platform();
+        assert_eq!(Type::AIX, version.os_type());
+    }
+}

--- a/os_info/src/bitness.rs
+++ b/os_info/src/bitness.rs
@@ -2,6 +2,7 @@
 
 use std::fmt::{self, Display, Formatter};
 #[cfg(any(
+    target_os = "aix",
     target_os = "dragonfly",
     target_os = "freebsd",
     target_os = "illumos",
@@ -88,9 +89,19 @@ pub fn get() -> Bitness {
     }
 }
 
+#[cfg(target_os = "aix")]
+pub fn get() -> Bitness {
+    match &Command::new("prtconf").arg("-c").output() {
+        Ok(Output { stdout, .. }) if stdout == b"CPU Type: 64-bit\n" => Bitness::X64,
+        Ok(Output { stdout, .. }) if stdout == b"CPU Type: 32-bit\n" => Bitness::X32,
+        _ => Bitness::Unknown,
+    }
+}
+
 #[cfg(all(
     test,
     any(
+        target_os = "aix",
         target_os = "dragonfly",
         target_os = "freebsd",
         target_os = "linux",

--- a/os_info/src/info.rs
+++ b/os_info/src/info.rs
@@ -208,6 +208,7 @@ mod tests {
     #[test]
     fn with_type() {
         let types = [
+            Type::AIX,
             Type::Redox,
             Type::Alpaquita,
             Type::Alpine,

--- a/os_info/src/lib.rs
+++ b/os_info/src/lib.rs
@@ -10,6 +10,10 @@
     missing_doc_code_examples
 )]
 
+#[cfg(target_os = "aix")]
+#[path = "aix/mod.rs"]
+mod imp;
+
 #[cfg(target_os = "android")]
 #[path = "android/mod.rs"]
 mod imp;
@@ -55,6 +59,7 @@ mod imp;
 mod imp;
 
 #[cfg(not(any(
+    target_os = "aix",
     target_os = "android",
     target_os = "dragonfly",
     target_os = "emscripten",
@@ -83,6 +88,7 @@ mod info;
 mod matcher;
 mod os_type;
 #[cfg(any(
+    target_os = "aix",
     target_os = "dragonfly",
     target_os = "freebsd",
     target_os = "illumos",

--- a/os_info/src/os_type.rs
+++ b/os_info/src/os_type.rs
@@ -6,6 +6,8 @@ use std::fmt::{self, Display, Formatter};
 #[allow(non_camel_case_types, clippy::upper_case_acronyms)]
 #[non_exhaustive]
 pub enum Type {
+    /// IBM AIX (<https://en.wikipedia.org/wiki/IBM_AIX>).
+    AIX,
     /// Alpaquita Linux (<https://bell-sw.com/alpaquita-linux/>).
     Alpaquita,
     /// Alpine Linux (<https://en.wikipedia.org/wiki/Alpine_Linux>).
@@ -133,6 +135,7 @@ mod tests {
     #[test]
     fn display() {
         let data = [
+            (Type::AIX, "AIX"),
             (Type::Alpaquita, "Alpaquita Linux"),
             (Type::Alpine, "Alpine Linux"),
             (Type::Amazon, "Amazon Linux AMI"),


### PR DESCRIPTION
Documentation for AIX `prtconf` command: https://www.ibm.com/docs/en/aix/7.2?topic=p-prtconf-command

> -c: Displays cpu type, for example, 32-bit or 64-bit.

Documentation for AIX `uname` command: https://www.ibm.com/docs/en/aix/7.2?topic=u-uname-command

> -r: Displays the release number of the operating system.
>
> -v: Displays the operating system version.