### PR TITLE
Add support for Kali Linux

### DIFF
--- a/os_info/src/linux/file_release.rs
+++ b/os_info/src/linux/file_release.rs
@@ -110,7 +110,7 @@ static DISTRIBUTIONS: [ReleaseInfo; 6] = [
                     "fedora" => Some(Type::Fedora),
                     //"gentoo" => Gentoo
                     //"ios_xr" => ios_xr
-                    //"kali" => Kali
+                    "kali" => Some(Type::Kali),
                     //"mageia" => Mageia
                     //"manjaro" => Manjaro
                     "linuxmint" => Some(Type::Mint),
@@ -382,6 +382,17 @@ mod tests {
         let info = retrieve(&DISTRIBUTIONS, root).unwrap();
         assert_eq!(info.os_type(), Type::Fedora);
         assert_eq!(info.version, Version::Unknown);
+        assert_eq!(info.edition, None);
+        assert_eq!(info.codename, None);
+    }
+
+    #[test]
+    fn kali_2023_2_os_release() {
+        let root = "src/linux/tests/Kali_2023_2";
+
+        let info = retrieve(&DISTRIBUTIONS, root).unwrap();
+        assert_eq!(info.os_type(), Type::Kali);
+        assert_eq!(info.version, Version::Semantic(2023, 2, 0));
         assert_eq!(info.edition, None);
         assert_eq!(info.codename, None);
     }

--- a/os_info/src/linux/lsb_release.rs
+++ b/os_info/src/linux/lsb_release.rs
@@ -26,6 +26,7 @@ pub fn get() -> Option<Info> {
         Some("Fedora") | Some("Fedora Linux") => Type::Fedora,
         Some("Garuda") => Type::Garuda,
         Some("Gentoo") => Type::Gentoo,
+        Some("Kali") => Type::Kali,
         Some("Linuxmint") => Type::Mint,
         Some("MaboxLinux") => Type::Mabox,
         Some("ManjaroLinux") => Type::Manjaro,
@@ -143,6 +144,14 @@ mod tests {
         assert_eq!(parse_results.distribution, Some("Fedora".to_string()));
         assert_eq!(parse_results.version, Some("26".to_string()));
         assert_eq!(parse_results.codename, Some("TwentySix".to_string()));
+    }
+
+    #[test]
+    fn kali_2023_2() {
+        let parse_results = parse(kali_2023_2_file());
+        assert_eq!(parse_results.distribution, Some("Kali".to_string()));
+        assert_eq!(parse_results.version, Some("2023.2".to_string()));
+        assert_eq!(parse_results.codename, Some("kali-rolling".to_string()));
     }
 
     #[test]
@@ -346,6 +355,14 @@ mod tests {
          Description:    Fedora release 26 (Twenty Six)\n\
          Release:    26\n\
          Codename:   TwentySix\n\
+         "
+    }
+
+    fn kali_2023_2_file() -> &'static str {
+        "\nDistributor ID: Kali\n\
+         Description:    Kali GNU/Linux Rolling\n\
+         Release:        2023.2\n\
+         Codename:       kali-rolling\n\
          "
     }
 

--- a/os_info/src/linux/mod.rs
+++ b/os_info/src/linux/mod.rs
@@ -37,6 +37,7 @@ mod tests {
             | Type::Fedora
             | Type::Garuda
             | Type::Gentoo
+            | Type::Kali
             | Type::Linux
             | Type::Mabox
             | Type::Manjaro

--- a/os_info/src/linux/tests/Kali_2023_2/etc/os-release
+++ b/os_info/src/linux/tests/Kali_2023_2/etc/os-release
@@ -1,0 +1,11 @@
+PRETTY_NAME="Kali GNU/Linux Rolling"
+NAME="Kali GNU/Linux"
+VERSION_ID="2023.2"
+VERSION="2023.2"
+VERSION_CODENAME=kali-rolling
+ID=kali
+ID_LIKE=debian
+HOME_URL="https://www.kali.org/"
+SUPPORT_URL="https://forums.kali.org/"
+BUG_REPORT_URL="https://bugs.kali.org/"
+ANSI_COLOR="1;31"

--- a/os_info/src/os_type.rs
+++ b/os_info/src/os_type.rs
@@ -42,6 +42,8 @@ pub enum Type {
     HardenedBSD,
     /// Illumos (https://en.wikipedia.org/wiki/Illumos).
     Illumos,
+    /// Kali Linux (https://en.wikipedia.org/wiki/Kali_Linux).
+    Kali,
     /// Linux based operating system (<https://en.wikipedia.org/wiki/Linux>).
     Linux,
     /// Mabox (<https://maboxlinux.org/>).
@@ -110,6 +112,7 @@ impl Display for Type {
             Type::Garuda => write!(f, "Garuda Linux"),
             Type::Gentoo => write!(f, "Gentoo Linux"),
             Type::Illumos => write!(f, "illumos"),
+            Type::Kali => write!(f, "Kali Linux"),
             Type::Macos => write!(f, "Mac OS"),
             Type::MidnightBSD => write!(f, "Midnight BSD"),
             Type::Mint => write!(f, "Linux Mint"),
@@ -151,6 +154,7 @@ mod tests {
             (Type::Garuda, "Garuda Linux"),
             (Type::Gentoo, "Gentoo Linux"),
             (Type::FreeBSD, "FreeBSD"),
+            (Type::Kali, "Kali Linux"),
             (Type::Linux, "Linux"),
             (Type::Macos, "Mac OS"),
             (Type::Manjaro, "Manjaro"),


### PR DESCRIPTION
I added support for Kali Linux. The example now produces:

```
OS information: Kali Linux 2023.2.0 [64-bit]
Type: Kali Linux
Version: 2023.2.0
Edition: None
Codename: None
Bitness: 64-bit
Architecture: Some("x86_64")
```

I hope the test are enugh like this. I am not sure if I didn't see more relevant testcases
