### PR TITLE
Linux/lsb_release: parse version string (#318)

### DIFF
--- a/os_info/src/linux/lsb_release.rs
+++ b/os_info/src/linux/lsb_release.rs
@@ -11,7 +11,7 @@ pub fn get() -> Option<Info> {
 
     let version = match release.version.as_deref() {
         Some("rolling") => Version::Rolling(None),
-        Some(v) => Version::Custom(v.to_owned()),
+        Some(v) => Version::from_string(v.to_owned()),
         None => Version::Unknown,
     };
 


### PR DESCRIPTION
When the lsb_release executable is not found the version is taken from /etc/os_release and properly parsed.  When it is found, however, the string was essentially not parsed, resulting in only Version::Custom objects to be returned.  Calling the proper parsing function does the trick, and Version::Semantic objects get created as expected.

The nearly manual handling of "rolling" for lsb_release, however, looks very suspicous, it should likely be folded to Version::from_string() instead.

