### PR TITLE
fix: netbsd - uname requires arg in 3.8.0

### DIFF
--- a/os_info/src/netbsd/mod.rs
+++ b/os_info/src/netbsd/mod.rs
@@ -7,7 +7,7 @@ use crate::{architecture, bitness, uname::uname, Info, Type, Version};
 pub fn current_platform() -> Info {
     trace!("netbsd::current_platform is called");
 
-    let version = uname()
+    let version = uname("-o")
         .map(Version::from_string)
         .unwrap_or_else(|| Version::Unknown);
 


### PR DESCRIPTION
Building for `x86_64-unknown-netbsd` results in an error after upgrading os_info to 3.8.0

```
error[E0061]: this function takes 1 argument but 0 arguments were supplied
  --> /home/runner/.cargo/git/checkouts/os_info-2e057b05809a1ca6/83fc567/os_info/src/netbsd/mod.rs:10:19
   |
10 |     let version = uname()
   |                   ^^^^^-- an argument of type `&str` is missing
   |
note: function defined here
  --> /home/runner/.cargo/git/checkouts/os_info-2e057b05809a1ca6/83fc567/os_info/src/uname.rs:5:8
   |
5  | pub fn uname(arg: &str) -> Option<String> {
   |        ^^^^^ ---------
help: provide the argument
   |
10 |     let version = uname(/* &str */)
   |                        ~~~~~~~~~~~~
```