### PR TITLE
Use uname -s to detect system name

### DIFF
--- a/os_info/src/aix/mod.rs
+++ b/os_info/src/aix/mod.rs
@@ -29,7 +29,7 @@ fn get_version() -> Option<String> {
 }
 
 fn get_os() -> Type {
-    match uname("-o").as_deref() {
+    match uname("-s").as_deref() {
         Some("AIX") => Type::AIX,
         _ => Type::Unknown,
     }


### PR DESCRIPTION
GNU style uname supports -o option, but AIX system's does not. Use -s to get system name, which is supported by both.
