### PR TITLE
Add   architecture information display

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -23,6 +23,9 @@ struct Options {
     /// Show OS bitness.
     #[clap(short, long)]
     bitness: bool,
+    /// Show OS arch.
+    #[clap(short = 'A', long = "Arch")]
+    architecture: bool,
 }
 
 fn main() {
@@ -31,16 +34,19 @@ fn main() {
     let options = Options::parse();
     let info = os_info::get();
 
-    if options.all || !(options.type_ || options.os_version || options.bitness) {
-        if options.type_ || options.os_version || options.bitness {
+    if options.all
+        || !(options.type_ || options.os_version || options.bitness || options.architecture)
+    {
+        if options.type_ || options.os_version || options.bitness || options.architecture {
             warn!("--all supersedes all other options");
         }
 
         println!(
-            "OS information:\nType: {}\nVersion: {}\nBitness: {}",
+            "OS information:\nType: {}\nVersion: {}\nBitness: {} \narchitecture:{}",
             info.os_type(),
             info.version(),
-            info.bitness()
+            info.bitness(),
+            info.architecture().unwrap()
         );
     } else {
         if options.type_ {
@@ -53,6 +59,10 @@ fn main() {
 
         if options.bitness {
             println!("OS bitness: {}", info.bitness());
+        }
+
+        if options.architecture {
+            println!("OS architecture: {}", info.architecture().unwrap());
         }
     }
 }

--- a/os_info/src/linux/lsb_release.rs
+++ b/os_info/src/linux/lsb_release.rs
@@ -66,7 +66,7 @@ struct LsbRelease {
 fn retrieve() -> Option<LsbRelease> {
     match Command::new("lsb_release").arg("-a").output() {
         Ok(output) => {
-            trace!("lsb_release command returned {:?}", output);
+            trace!("lsb_release command returned {:?}", output); //日志信息
             Some(parse(&String::from_utf8_lossy(&output.stdout)))
         }
         Err(e) => {
@@ -76,6 +76,7 @@ fn retrieve() -> Option<LsbRelease> {
     }
 }
 
+// 解析
 fn parse(output: &str) -> LsbRelease {
     trace!("Trying to parse {:?}", output);
 
@@ -188,21 +189,15 @@ mod tests {
     #[test]
     fn nobara() {
         let parse_results = parse(nobara_file());
-        assert_eq!(
-            parse_results.distribution,
-            Some("NobaraLinux".to_string())
-        );
+        assert_eq!(parse_results.distribution, Some("NobaraLinux".to_string()));
         assert_eq!(parse_results.version, Some("39".to_string()));
         assert_eq!(parse_results.codename, None);
     }
 
     #[test]
-    fn Uos() {
+    fn uos() {
         let parse_results = parse(uos_file());
-        assert_eq!(
-            parse_results.distribution,
-            Some("uos".to_string())
-        );
+        assert_eq!(parse_results.distribution, Some("uos".to_string()));
         assert_eq!(parse_results.version, Some("20".to_string()));
         assert_eq!(parse_results.codename, Some("eagle".to_string()));
     }


### PR DESCRIPTION
<!--
Add architecture information display
![image](https://github.com/stanislav-tkach/os_info/assets/98640292/466a5af9-9d9b-416e-9e4c-2056d70a143c)

 
ues command "os_info -A"  or "os_info --Arch"  can display display.
![image](https://github.com/stanislav-tkach/os_info/assets/98640292/2d0fb3fb-5c00-41cb-8d8d-bd7b0f0e41c8)

-->
