### PR TITLE
Add support for MicroOS

### DIFF
--- a/os_info/src/linux/file_release.rs
+++ b/os_info/src/linux/file_release.rs
@@ -125,6 +125,7 @@ static DISTRIBUTIONS: [ReleaseInfo; 6] = [
                     "ol" => Some(Type::OracleLinux),
                     "opensuse" => Some(Type::openSUSE),
                     "opensuse-leap" => Some(Type::openSUSE),
+                    "opensuse-microos" => Some(Type::openSUSE),
                     "opensuse-tumbleweed" => Some(Type::openSUSE),
                     //"rancheros" => RancherOS
                     //"raspbian" => Raspbian


### PR DESCRIPTION
<!--
Please describe the pull request motivation and changes here along with non-obvious things.
-->

Not sure if this is sufficient but happy to extend this further if needed. MicroOS is a specific repackaging of Tumbleweed, so this classification is probably sufficient.

`/etc/os-release`:

```
NAME="openSUSE MicroOS"
# VERSION="20241112"
ID="opensuse-microos"
ID_LIKE="suse opensuse opensuse-tumbleweed microos sl-micro"
VERSION_ID="20241112"
PRETTY_NAME="openSUSE MicroOS"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:opensuse:microos:20241112"
BUG_REPORT_URL="https://bugzilla.opensuse.org"
SUPPORT_URL="https://bugs.opensuse.org"
HOME_URL="https://www.opensuse.org/"
DOCUMENTATION_URL="https://en.opensuse.org/Portal:MicroOS"
LOGO="distributor-logo-MicroOS"
```
