### PR TITLE
Exclude testdata from published crate

### DIFF
--- a/os_info/Cargo.toml
+++ b/os_info/Cargo.toml
@@ -12,6 +12,12 @@ categories = ["os"]
 license = "MIT"
 edition = "2018"
 rust-version = "1.60"
+include = [
+    "Cargo.toml",
+    "LICENSE",
+    "src/**/*.rs",
+    "README.md",
+]
 
 [features]
 default = ["serde"]


### PR DESCRIPTION
This commit removes the test data from the published crate.

Fixes #389

<!--
Please describe the pull request motivation and changes here along with non-obvious things.
-->
