### PR TITLE
Fix NetBSD support.

### DIFF
--- a/os_info/src/netbsd/mod.rs
+++ b/os_info/src/netbsd/mod.rs
@@ -7,7 +7,7 @@ use crate::{architecture, bitness, uname::uname, Info, Type, Version};
 pub fn current_platform() -> Info {
     trace!("netbsd::current_platform is called");
 
-    let version = uname("-o")
+    let version = uname("-s")
         .map(Version::from_string)
         .unwrap_or_else(|| Version::Unknown);
 

--- a/os_info/src/uname.rs
+++ b/os_info/src/uname.rs
@@ -26,7 +26,7 @@ mod tests {
 
     #[test]
     fn uname_nonempty() {
-        let val = uname().expect("uname failed");
+        let val = uname("-s").expect("uname failed");
         assert!(!val.is_empty());
     }
 }


### PR DESCRIPTION
uname(1) on NetBSD doesn't support '-o', use '-s' instead.

Add missing argument in a test while here.

After these changes, 'cargo test' succeeds on NetBSD.

Addresses https://github.com/fish-shell/fish-shell/issues/10981 which was caused by https://github.com/stanislav-tkach/os_info/pull/374