### PR TITLE
Fix doc - add more friendly web-link for Type::Uos

### DIFF
--- a/os_info/src/os_type.rs
+++ b/os_info/src/os_type.rs
@@ -100,7 +100,7 @@ pub enum Type {
     Ubuntu,
     /// Ultramarine (<https://ultramarine-linux.org/>).
     Ultramarine,
-    /// Uos (<https://www.chinauos.com/>).
+    /// Uos (<https://uos.uniontech.com/>).
     Uos,
     /// Void Linux (<https://en.wikipedia.org/wiki/Void_Linux>).
     Void,


### PR DESCRIPTION
There is dedicated web-site for UnionTech Desktop Operation System - let's have it in doc instead of site about UnionTech company in Chinese