### PR TITLE
Use SystemVersion.plist for macOS ProductVersion

### DIFF
--- a/os_info/Cargo.toml
+++ b/os_info/Cargo.toml
@@ -37,6 +37,9 @@ windows-sys = { version = "0.52", features = [
     "Win32_UI_WindowsAndMessaging",
 ] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+plist = "1.5.1"
+
 [dev-dependencies]
 pretty_assertions = "1"
 doc-comment = "0.3"


### PR DESCRIPTION
<!--
Please describe the pull request motivation and changes here along with non-obvious things.
-->

This PR changes the version detection on macOS to read the data from the `SystemVersion.plist`-file instead of calling an external command. I've kept the old external-command method as a fallback, but it might make sense to remove it.

Closes #333

Besides this I also noticed that `getconf` is called as an external command to determine the bitness on macOS, would you be open to using native APIs for this as well (e.g. via `libc`, `nix`, `rustix` or manual bindings)? This would improve performance on my system from 17ms to <1ms.