### PR TITLE
add feature to enable json-schema generation via schemars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          feature-group: default-features
 
   # Tests.
   test:
@@ -117,9 +119,9 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --examples --all
+          args: --examples --all --all-features
       - name: Test
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all
+          args: --all --all-features

--- a/os_info/Cargo.toml
+++ b/os_info/Cargo.toml
@@ -24,6 +24,7 @@ default = ["serde"]
 
 [dependencies]
 log.workspace = true
+schemars = { version = "1.0.3", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 
 [target.'cfg(windows)'.dependencies]

--- a/os_info/src/bitness.rs
+++ b/os_info/src/bitness.rs
@@ -16,6 +16,7 @@ use std::process::{Command, Output};
 
 /// Operating system architecture in terms of how many bits compose the basic values it can deal with.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[non_exhaustive]
 pub enum Bitness {

--- a/os_info/src/info.rs
+++ b/os_info/src/info.rs
@@ -19,6 +19,7 @@ use super::{Bitness, Type, Version};
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Info {
     /// Operating system type. See `Type` for details.
     pub(crate) os_type: Type,

--- a/os_info/src/os_type.rs
+++ b/os_info/src/os_type.rs
@@ -2,6 +2,7 @@ use std::fmt::{self, Display, Formatter};
 
 /// A list of supported operating system types.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[allow(non_camel_case_types, clippy::upper_case_acronyms)]
 #[non_exhaustive]

--- a/os_info/src/version.rs
+++ b/os_info/src/version.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 /// Operating system version.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum Version {
     /// Unknown version.
     Unknown,


### PR DESCRIPTION
<!--
Please describe the pull request motivation and changes here along with non-obvious things.
-->
This PR adds support for JSON-schema generation support via `schemars` for all types that implement the `serde` traits. JSON-schema can give config files a schema for validation and assistance in text editor environments. At a minimum `schemars` v1.0.3 (versus just `v1` like serde) is required to support rust edition 2018.

To avoid increasing the MSRV unduly, I amended the MSRV check to restrict itself to default features and ensured the feature is enabled in regular CI checks.

With the upgrade to schemars 1.0 map keys as used in starship are required to implement the `JsonSchema` trait instead of it assuming string keys. If this feature is not acceptable this could be worked around in starship, but eventually having a schema for `os_info` types in the starship config schema (the extra information is not used by `schemars` yet) would be nice to have.