### PR TITLE
Fix Registry Key Handle Leak on Windows

### DIFF
--- a/os_info/src/windows/winapi.rs
+++ b/os_info/src/windows/winapi.rs
@@ -16,7 +16,7 @@ use windows_sys::Win32::{
     Foundation::{ERROR_SUCCESS, FARPROC, NTSTATUS, STATUS_SUCCESS},
     System::{
         LibraryLoader::{GetModuleHandleA, GetProcAddress},
-        Registry::{RegOpenKeyExW, RegQueryValueExW, HKEY_LOCAL_MACHINE, KEY_READ, REG_SZ},
+        Registry::{RegCloseKey, RegOpenKeyExW, RegQueryValueExW, HKEY, HKEY_LOCAL_MACHINE, KEY_READ, REG_SZ},
         SystemInformation::{
             GetNativeSystemInfo, GetSystemInfo, PROCESSOR_ARCHITECTURE_AMD64,
             PROCESSOR_ARCHITECTURE_ARM, PROCESSOR_ARCHITECTURE_IA64, PROCESSOR_ARCHITECTURE_INTEL,
@@ -34,6 +34,14 @@ type OSVERSIONINFOEX = windows_sys::Win32::System::SystemInformation::OSVERSIONI
 
 #[cfg(not(target_arch = "x86"))]
 type OSVERSIONINFOEX = windows_sys::Win32::System::SystemInformation::OSVERSIONINFOEXW;
+
+struct HKeyWrap(HKEY);
+
+impl Drop for HKeyWrap {
+    fn drop(&mut self) {
+        unsafe { RegCloseKey(self.0) };
+    }
+}
 
 pub fn get() -> Info {
     let (version, edition) = version();
@@ -148,10 +156,10 @@ fn version_info() -> Option<OSVERSIONINFOEX> {
 
 fn product_name(info: &OSVERSIONINFOEX) -> Option<String> {
     let sub_key = to_wide("SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion");
-    let mut key = Default::default();
-    if unsafe { RegOpenKeyExW(HKEY_LOCAL_MACHINE, sub_key.as_ptr(), 0, KEY_READ, &mut key) }
+    let mut key = HKeyWrap(Default::default());
+    if unsafe { RegOpenKeyExW(HKEY_LOCAL_MACHINE, sub_key.as_ptr(), 0, KEY_READ, &mut key.0) }
         != ERROR_SUCCESS
-        || key == 0
+        || key.0 == 0
     {
         log::error!("RegOpenKeyExW(HKEY_LOCAL_MACHINE, ...) failed");
         return None;
@@ -169,7 +177,7 @@ fn product_name(info: &OSVERSIONINFOEX) -> Option<String> {
     let mut data_size = 0;
     if unsafe {
         RegQueryValueExW(
-            key,
+            key.0,
             name.as_ptr(),
             ptr::null_mut(),
             &mut data_type,
@@ -189,7 +197,7 @@ fn product_name(info: &OSVERSIONINFOEX) -> Option<String> {
     let mut data = vec![0u16; data_size as usize / 2];
     if unsafe {
         RegQueryValueExW(
-            key,
+            key.0,
             name.as_ptr(),
             ptr::null_mut(),
             ptr::null_mut(),


### PR DESCRIPTION
## Changes

This change introduces a wrapper around HKEY that automatically releases/closes the registry key handle when the object goes out of scope.

## Why

On Windows, I noticed that my application was opening a large number of handles to the registry key: `HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion`

Upon investigation, it appears that this lib isn't closing registry key handles after opening them, which results in handle leaks over time. 

I thought about refactoring my app to not call `os_info::get()` so many times, but it's probably better to submit a small fix :)

## Reproduction

This small program reproduces the issue

```rust
use os_info;

fn main() {
    for n in 0..20 {
        let a = os_info::get();
        println!("# {n} - {}", a.version());
    }

    std::thread::park();
}
```

### Before fix

From Process Explorer, we can observe running this program results in 20 handles being held open.

<img width="60%" alt="image" src="https://github.com/user-attachments/assets/84047f64-43b7-483a-a215-5307c73d0a70" />

### After fix

Process Explorer confirms we are no longer holding open Reg Key handles

<img width="60%" alt="image" src="https://github.com/user-attachments/assets/1ee71ed5-7429-428a-b631-650b0c0c265d" />
