### PR TITLE
Android version support

### DIFF
--- a/os_info/Cargo.toml
+++ b/os_info/Cargo.toml
@@ -26,6 +26,9 @@ default = ["serde"]
 log.workspace = true
 serde = { version = "1", features = ["derive"], optional = true }
 
+[target.'cfg(target_os = "android")'.dependencies]
+android_system_properties = "0.1"
+
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.52", features = [
     "Win32_Foundation",

--- a/os_info/src/android/mod.rs
+++ b/os_info/src/android/mod.rs
@@ -1,13 +1,35 @@
 use log::trace;
 
-use crate::{Bitness, Info, Type};
+use crate::{Bitness, Info, Type, Version};
+
+use android_system_properties::AndroidSystemProperties;
 
 pub fn current_platform() -> Info {
     trace!("android::current_platform is called");
 
-    let info = Info::with_type(Type::Android);
+    let bitness = match std::env::consts::ARCH {
+        "x86" | "arm" => Bitness::X32,
+        "x86_64" | "aarch64" => Bitness::X64,
+        _ => Bitness::Unknown,
+    };
+
+    let info = Info {
+        os_type: Type::Android,
+        version: version(),
+        bitness,
+        ..Default::default()
+    };
     trace!("Returning {:?}", info);
     info
+}
+
+fn version() -> Version {
+    let android_system_properties = AndroidSystemProperties::new();
+
+    match android_system_properties.get("ro.build.version.release") {
+        Some(v) => Version::from_string(v),
+        None => Version::Unknown,
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add Android support for Info::current().

Without this, Aptabase Analytics showed unknown for Android versions in the dashboard.

Before:
<img width="352" height="88" alt="image" src="https://github.com/user-attachments/assets/03913905-2353-4d0b-9b26-c7586c671d81" />

After:
<img width="362" height="96" alt="image" src="https://github.com/user-attachments/assets/1843dcef-ccf4-46ff-9b61-452a44f66931" />

Changes
	•	Read OS version and codename from ro.build.version.*.
	•	Parse version into Version enum.
	•	Determine bitness from std::env::consts::ARCH.