### PR TITLE
Use native uname API if possible

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -39,6 +39,7 @@ musl
 netbsd
 nixos
 nobara
+nodename
 uos
 openbsd
 opencloudos
@@ -55,6 +56,7 @@ serde
 structopt
 toml
 ulyana
+utsname
 virtuozzo
 winapi
 xbian
@@ -65,3 +67,5 @@ ultramarine
 uninit
 voidlinux
 kuma
+syscall
+sysname

--- a/os_info/Cargo.toml
+++ b/os_info/Cargo.toml
@@ -45,6 +45,9 @@ windows-sys = { version = "0.52", features = [
     "Win32_UI_WindowsAndMessaging",
 ] }
 
+[target.'cfg(any(target_os = "aix", target_os = "dragonfly", target_os = "freebsd", target_os = "illumos", target_os = "linux", target_os = "macos", target_os = "netbsd", target_os = "openbsd", target_os = "cygwin"))'.dependencies]
+nix = { version = "0.26", features = ["feature"] }
+
 [target.'cfg(target_os = "macos")'.dependencies]
 plist = "1.5.1"
 

--- a/os_info/src/aix/mod.rs
+++ b/os_info/src/aix/mod.rs
@@ -2,7 +2,11 @@ use std::{process::Command, str};
 
 use log::{error, trace};
 
-use crate::{bitness, uname::uname, Info, Type, Version};
+use crate::{
+    bitness,
+    uname::{uname, UnameField},
+    Info, Type, Version,
+};
 
 pub fn current_platform() -> Info {
     trace!("aix::current_platform is called");
@@ -23,13 +27,13 @@ pub fn current_platform() -> Info {
 }
 
 fn get_version() -> Option<String> {
-    let major = uname("-v")?;
-    let minor = uname("-r").unwrap_or(String::from("0"));
+    let major = uname(UnameField::Version)?;
+    let minor = uname(UnameField::Release).unwrap_or(String::from("0"));
     Some(format!("{}.{}", major, minor))
 }
 
 fn get_os() -> Type {
-    match uname("-s").as_deref() {
+    match uname(UnameField::Sysname).as_deref() {
         Some("AIX") => Type::AIX,
         _ => Type::Unknown,
     }

--- a/os_info/src/architecture.rs
+++ b/os_info/src/architecture.rs
@@ -1,23 +1,7 @@
-use std::process::Command;
-
-use log::error;
+use crate::uname::{uname, UnameField};
 
 pub fn get() -> Option<String> {
-    Command::new("uname")
-        .arg("-m")
-        .output()
-        .map_err(|e| {
-            error!("Cannot invoke 'uname` to get architecture type: {:?}", e);
-        })
-        .ok()
-        .and_then(|out| {
-            if out.status.success() {
-                Some(String::from_utf8_lossy(&out.stdout).trim_end().to_owned())
-            } else {
-                log::error!("'uname' invocation error: {:?}", out);
-                None
-            }
-        })
+    uname(UnameField::Machine)
 }
 
 #[cfg(test)]

--- a/os_info/src/cygwin/mod.rs
+++ b/os_info/src/cygwin/mod.rs
@@ -2,12 +2,16 @@ use std::process::Command;
 
 use log::{error, trace};
 
-use crate::{architecture, bitness, uname::uname, Info, Type, Version};
+use crate::{
+    architecture, bitness,
+    uname::{uname, UnameField},
+    Info, Type, Version,
+};
 
 pub fn current_platform() -> Info {
     trace!("cygwin::current_platform is called");
 
-    let version = uname("-r")
+    let version = uname(UnameField::Release)
         .map(Version::from_string)
         .unwrap_or_else(|| Version::Unknown);
 

--- a/os_info/src/dragonfly/mod.rs
+++ b/os_info/src/dragonfly/mod.rs
@@ -2,12 +2,16 @@ use std::process::Command;
 
 use log::trace;
 
-use crate::{bitness, uname::uname, Bitness, Info, Type, Version};
+use crate::{
+    bitness,
+    uname::{uname, UnameField},
+    Bitness, Info, Type, Version,
+};
 
 pub fn current_platform() -> Info {
     trace!("dragonfly::current_platform is called");
 
-    let version = uname("-r")
+    let version = uname(UnameField::Release)
         .map(Version::from_string)
         .unwrap_or_else(|| Version::Unknown);
 

--- a/os_info/src/freebsd/mod.rs
+++ b/os_info/src/freebsd/mod.rs
@@ -3,12 +3,16 @@ use std::str;
 
 use log::{error, trace};
 
-use crate::{bitness, uname::uname, Info, Type, Version};
+use crate::{
+    bitness,
+    uname::{uname, UnameField},
+    Info, Type, Version,
+};
 
 pub fn current_platform() -> Info {
     trace!("freebsd::current_platform is called");
 
-    let version = uname("-r")
+    let version = uname(UnameField::Release)
         .map(Version::from_string)
         .unwrap_or_else(|| Version::Unknown);
 
@@ -24,7 +28,7 @@ pub fn current_platform() -> Info {
 }
 
 fn get_os() -> Type {
-    match uname("-s").as_deref() {
+    match uname(UnameField::Sysname).as_deref() {
         Some("MidnightBSD") => Type::MidnightBSD,
         Some("FreeBSD") => {
             let check_hardening = match Command::new("/sbin/sysctl")

--- a/os_info/src/illumos/mod.rs
+++ b/os_info/src/illumos/mod.rs
@@ -3,12 +3,16 @@ use std::str;
 
 use log::{error, trace};
 
-use crate::{bitness, uname::uname, Info, Type, Version};
+use crate::{
+    bitness,
+    uname::{uname, UnameField},
+    Info, Type, Version,
+};
 
 pub fn current_platform() -> Info {
     trace!("illumos::current_platform is called");
 
-    let version = uname("-v")
+    let version = uname(UnameField::Version)
         .map(Version::from_string)
         .unwrap_or_else(|| Version::Unknown);
 
@@ -24,7 +28,7 @@ pub fn current_platform() -> Info {
 }
 
 fn get_os() -> Type {
-    match uname("-o").as_deref() {
+    match uname(UnameField::OperatingSystem).as_deref() {
         Some("illumos") => Type::Illumos,
         _ => Type::Unknown,
     }

--- a/os_info/src/lib.rs
+++ b/os_info/src/lib.rs
@@ -103,6 +103,8 @@ mod os_type;
     target_os = "dragonfly",
     target_os = "freebsd",
     target_os = "illumos",
+    target_os = "linux",
+    target_os = "macos",
     target_os = "netbsd",
     target_os = "openbsd",
     target_os = "cygwin"

--- a/os_info/src/netbsd/mod.rs
+++ b/os_info/src/netbsd/mod.rs
@@ -2,12 +2,16 @@ use std::process::Command;
 
 use log::{error, trace};
 
-use crate::{architecture, bitness, uname::uname, Info, Type, Version};
+use crate::{
+    architecture, bitness,
+    uname::{uname, UnameField},
+    Info, Type, Version,
+};
 
 pub fn current_platform() -> Info {
     trace!("netbsd::current_platform is called");
 
-    let version = uname("-s")
+    let version = uname(UnameField::Sysname)
         .map(Version::from_string)
         .unwrap_or_else(|| Version::Unknown);
 

--- a/os_info/src/openbsd/mod.rs
+++ b/os_info/src/openbsd/mod.rs
@@ -2,12 +2,16 @@ use std::process::Command;
 
 use log::{error, trace};
 
-use crate::{architecture, bitness, uname::uname, Info, Type, Version};
+use crate::{
+    architecture, bitness,
+    uname::{uname, UnameField},
+    Info, Type, Version,
+};
 
 pub fn current_platform() -> Info {
     trace!("openbsd::current_platform is called");
 
-    let version = uname("-r")
+    let version = uname(UnameField::Release)
         .map(Version::from_string)
         .unwrap_or_else(|| Version::Unknown);
 

--- a/os_info/src/uname.rs
+++ b/os_info/src/uname.rs
@@ -1,8 +1,67 @@
+use log::error;
+use nix::sys::utsname::uname as nix_uname;
 use std::process::Command;
 
-use log::error;
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(dead_code)]
+pub enum UnameField {
+    Sysname,
+    Release,
+    Version,
+    Machine,
+    Nodename,
+    OperatingSystem,
+}
 
-pub fn uname(arg: &str) -> Option<String> {
+impl UnameField {
+    fn cli_arg_name(&self) -> &'static str {
+        match self {
+            UnameField::Sysname => "-s",
+            UnameField::Release => "-r",
+            UnameField::Version => "-v",
+            UnameField::Machine => "-m",
+            UnameField::Nodename => "-n",
+            UnameField::OperatingSystem => "-o",
+        }
+    }
+
+    fn supports_uname_syscall(&self) -> bool {
+        self != &UnameField::OperatingSystem
+    }
+
+    fn get_from_syscall(&self) -> Option<String> {
+        if !self.supports_uname_syscall() {
+            return None;
+        }
+
+        let utsname = match nix_uname() {
+            Ok(utsname) => utsname,
+            Err(e) => {
+                log::error!("Failed to invoke native uname: {e:?}");
+                return None;
+            }
+        };
+
+        let val_os = match self {
+            UnameField::Sysname => utsname.sysname(),
+            UnameField::Release => utsname.release(),
+            UnameField::Version => utsname.version(),
+            UnameField::Machine => utsname.machine(),
+            UnameField::Nodename => utsname.nodename(),
+            UnameField::OperatingSystem => return None,
+        };
+
+        let val = val_os.to_str();
+        if val.is_none() {
+            error!("Failed to convert uname value to string: {val_os:?}");
+            return None;
+        }
+
+        val.map(String::from)
+    }
+}
+
+fn uname_cli(arg: &str) -> Option<String> {
     Command::new("uname")
         .arg(arg)
         .output()
@@ -14,10 +73,16 @@ pub fn uname(arg: &str) -> Option<String> {
             if out.status.success() {
                 Some(String::from_utf8_lossy(&out.stdout).trim_end().to_owned())
             } else {
-                log::error!("'uname' invocation error: {:?}", out);
+                error!("'uname {}' failed with status: {:?}", arg, out.status);
                 None
             }
         })
+}
+
+pub fn uname(field: UnameField) -> Option<String> {
+    field
+        .get_from_syscall()
+        .or_else(|| uname_cli(field.cli_arg_name()))
 }
 
 #[cfg(test)]
@@ -26,7 +91,7 @@ mod tests {
 
     #[test]
     fn uname_nonempty() {
-        let val = uname("-s").expect("uname failed");
+        let val = uname(UnameField::Sysname).expect("uname failed");
         assert!(!val.is_empty());
     }
 }


### PR DESCRIPTION
<!--
Please describe the pull request motivation and changes here along with non-obvious things.
-->
The primary motivation is performance; See also #375

I changed `uname` to take an `enum` argument based on the desired uname-value to make it easier to replace `uname("string-arg")` with `uname(enum-value)` as-is. If the value is not supported by the nix api (`-o`/`OperatingSystem`) or if the `uname`-call fails, the implementation falls back to the CLI. In the future it might make sense to optimise this further such that multiple `uname` calls are joined together.

Testing running via on macOS, Windows, and Linux. Tested compilation via `cross` for FreeBSD and NetBSD.