### PR TITLE
refactor: use native xml parser on macos

### DIFF
--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -40,6 +40,7 @@ netbsd
 nixos
 nobara
 uos
+objc
 openbsd
 opencloudos
 openeuler

--- a/os_info/Cargo.toml
+++ b/os_info/Cargo.toml
@@ -34,6 +34,14 @@ objc2 = "0.6"
 objc2-foundation = { version = "0.3", features = ["NSString"] }
 objc2-ui-kit = "0.3"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2-foundation = { version = "0.3", features = [
+    "NSData",
+    "NSError",
+    "NSEnumerator",
+    "NSString",
+] }
+
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.52", features = [
     "Win32_Foundation",
@@ -45,8 +53,6 @@ windows-sys = { version = "0.52", features = [
     "Win32_UI_WindowsAndMessaging",
 ] }
 
-[target.'cfg(target_os = "macos")'.dependencies]
-plist = "1.5.1"
 
 [dev-dependencies]
 pretty_assertions = "1"


### PR DESCRIPTION
<!--
Please describe the pull request motivation and changes here along with non-obvious things.
-->
Using native APIs via `objc2-foundation` keeps dependency tree somewhat smaller, avoiding a dependency on a full-blown XML-parser.
`product_version_from_file` contains `unsafe`, but contains appropriate checks.