### PR TITLE
alias Raspbian to new name RaspberryPiOS

### DIFF
--- a/os_info/src/os_type.rs
+++ b/os_info/src/os_type.rs
@@ -89,6 +89,7 @@ pub enum Type {
     /// Pop!_OS (<https://en.wikipedia.org/wiki/Pop!_OS>)
     Pop,
     /// Raspberry Pi OS (<https://en.wikipedia.org/wiki/Raspberry_Pi_OS>).
+    #[cfg_attr(feature = "serde", serde(alias = "RaspberryPiOS"))]
     Raspbian,
     /// Red Hat Linux (<https://en.wikipedia.org/wiki/Red_Hat_Linux>).
     Redhat,


### PR DESCRIPTION
<!--
Please describe the pull request motivation and changes here along with non-obvious things.
-->
The alias allows using the more recent name `RaspberryPiOS` with `serde` without breaking API compatibility.

Related: https://github.com/starship/starship/issues/6739