### PR TITLE
Add support for Parrot OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Right now, the following operating system types can be returned:
 - openEuler (EulerOS)
 - openSUSE
 - Oracle Linux
+- Parrot OS
 - Pop!_OS
 - Raspberry Pi OS
 - Red Hat Linux

--- a/os_info/src/linux/file_release.rs
+++ b/os_info/src/linux/file_release.rs
@@ -109,9 +109,15 @@ static DISTRIBUTIONS: [ReleaseInfo; 6] = [
                     //"coreos"
                     //"cumulus-linux" => Cumulus
                     "debian" => {
-                        // Check if it's actually Raspberry Pi OS
+                        // Check if it's actually Raspberry Pi OS or Parrot OS
                         if std::path::Path::new("/etc/rpi-issue").exists() {
                             Some(Type::Raspbian)
+                        } else if (Matcher::KeyValue { key: "NAME" })
+                            .find(release)
+                            .as_deref()
+                            == Some("Parrot Security")
+                        {
+                            Some(Type::Parrot)
                         } else {
                             Some(Type::Debian)
                         }
@@ -140,6 +146,7 @@ static DISTRIBUTIONS: [ReleaseInfo; 6] = [
                     "opensuse-leap" => Some(Type::openSUSE),
                     "opensuse-microos" => Some(Type::openSUSE),
                     "opensuse-tumbleweed" => Some(Type::openSUSE),
+                    "parrot" => Some(Type::Parrot),
                     "pika" => Some(Type::PikaOS),
                     //"rancheros" => RancherOS
                     //"raspbian" => Raspbian
@@ -760,6 +767,17 @@ mod tests {
         let info = retrieve(&DISTRIBUTIONS, root).unwrap();
         assert_eq!(info.os_type(), Type::CachyOS);
         assert_eq!(info.version, Version::Unknown);
+        assert_eq!(info.edition, None);
+        assert_eq!(info.codename, None);
+    }
+
+    #[test]
+    fn parrot_os_release() {
+        let root = "src/linux/tests/Parrot";
+
+        let info = retrieve(&DISTRIBUTIONS, root).unwrap();
+        assert_eq!(info.os_type(), Type::Parrot);
+        assert_eq!(info.version, Version::Semantic(7, 2, 0));
         assert_eq!(info.edition, None);
         assert_eq!(info.codename, None);
     }

--- a/os_info/src/linux/lsb_release.rs
+++ b/os_info/src/linux/lsb_release.rs
@@ -26,9 +26,11 @@ pub fn get() -> Option<Info> {
         Some("cachyos") => Type::CachyOS,
         Some("CentOS") => Type::CentOS,
         Some("Debian") => {
-            // Check if it's actually Raspberry Pi OS
+            // Check if it's actually Raspberry Pi OS or Parrot OS
             if std::path::Path::new("/etc/rpi-issue").exists() {
                 Type::Raspbian
+            } else if std::path::Path::new("/etc/apt/sources.list.d/parrot.list").exists() {
+                Type::Parrot
             } else {
                 Type::Debian
             }

--- a/os_info/src/linux/mod.rs
+++ b/os_info/src/linux/mod.rs
@@ -57,6 +57,7 @@ mod tests {
             | Type::openEuler
             | Type::openSUSE
             | Type::OracleLinux
+            | Type::Parrot
             | Type::PikaOS
             | Type::Pop
             | Type::Raspbian

--- a/os_info/src/linux/tests/Parrot/etc/os-release
+++ b/os_info/src/linux/tests/Parrot/etc/os-release
@@ -1,0 +1,10 @@
+PRETTY_NAME="Parrot Security 7.2 (echo)"
+NAME="Parrot Security"
+VERSION_ID="7.2"
+VERSION="7.2 (echo)"
+VERSION_CODENAME=echo
+DEBIAN_VERSION_FULL=7.2
+ID=debian
+HOME_URL="https://www.parrotsec.org/"
+SUPPORT_URL="https://www.parrotsec.org/docs"
+BUG_REPORT_URL="https://gitlab.com/parrotsec/"

--- a/os_info/src/os_type.rs
+++ b/os_info/src/os_type.rs
@@ -99,6 +99,8 @@ pub enum Type {
     openSUSE,
     /// Oracle Linux (<https://en.wikipedia.org/wiki/Oracle_Linux>).
     OracleLinux,
+    /// Parrot OS (<https://en.wikipedia.org/wiki/Parrot_OS>).
+    Parrot,
     /// PikaOS (<https://wiki.pika-os.com/en/home>)
     PikaOS,
     /// Pop!_OS (<https://en.wikipedia.org/wiki/Pop!_OS>)
@@ -169,6 +171,7 @@ impl Display for Type {
             Type::Nobara => write!(f, "Nobara Linux"),
             Type::openEuler => write!(f, "EulerOS"),
             Type::OracleLinux => write!(f, "Oracle Linux"),
+            Type::Parrot => write!(f, "Parrot OS"),
             Type::PikaOS => write!(f, "PikaOS"),
             Type::Pop => write!(f, "Pop!_OS"),
             Type::Raspbian => write!(f, "Raspberry Pi OS"),
@@ -242,6 +245,7 @@ mod tests {
             (Type::openEuler, "EulerOS"),
             (Type::openSUSE, "openSUSE"),
             (Type::OracleLinux, "Oracle Linux"),
+            (Type::Parrot, "Parrot OS"),
             (Type::PikaOS, "PikaOS"),
             (Type::Pop, "Pop!_OS"),
             (Type::Raspbian, "Raspberry Pi OS"),


### PR DESCRIPTION
Adds support for [Parrot OS](https://en.wikipedia.org/wiki/Parrot_OS).

I've added two detection paths in [os_info/src/linux/file_release.rs](os_info/src/linux/file_release.rs). Current versions of Parrot OS (I use the latest version, 7.2) set `ID=debian` and `NAME=Parrot Security`. However I found [evidence](https://github.com/tailscale/tailscale/pull/14487) that older versions may have set `ID=parrot` (and, [hopefully](https://community.parrotsec.org/t/parrot-os-id-debian/30119), some future version will set it to `ID=parrot` again).

If this is considered too messy, I'd drop the check for `ID=parrot`, since that is not what my system reports, though I have not checked any other editions of Parrot OS.

Thanks for the cool library! Hoping to get ParrotOS support in Starship after this PR :)