### PR TITLE
Add support for Azure Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Azure Linux support has been added.
+
 ## [3.15.0] (2026-05-19)
 
 - KDE neon support has been added. (#433)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Right now, the following operating system types can be returned:
 - AOSC OS
 - Arch Linux
 - Artix Linux
+- Azure Linux
 - Bazzite
 - CachyOS
 - CentOS

--- a/cspell-dictionary.txt
+++ b/cspell-dictionary.txt
@@ -6,6 +6,7 @@ antergos
 aosc
 archarm
 artix
+azurelinux
 bazzite
 bitness
 cachy

--- a/os_info/src/info.rs
+++ b/os_info/src/info.rs
@@ -219,6 +219,7 @@ mod tests {
             Type::AOSC,
             Type::Arch,
             Type::Artix,
+            Type::AzureLinux,
             Type::Bluefin,
             Type::CachyOS,
             Type::CentOS,

--- a/os_info/src/linux/file_release.rs
+++ b/os_info/src/linux/file_release.rs
@@ -109,6 +109,7 @@ static DISTRIBUTIONS: [ReleaseInfo; 6] = [
                     "arch" => Some(Type::Arch),
                     "archarm" => Some(Type::Arch),
                     "artix" => Some(Type::Artix),
+                    "azurelinux" => Some(Type::AzureLinux),
                     "bazzite" => Some(Type::Bazzite),
                     "bluefin" => Some(Type::Bluefin),
                     "cachyos" => Some(Type::CachyOS),
@@ -347,6 +348,28 @@ mod tests {
 
         let info = retrieve(&DISTRIBUTIONS, root).unwrap();
         assert_eq!(info.os_type(), Type::Arch);
+        assert_eq!(info.version, Version::Unknown);
+        assert_eq!(info.edition, None);
+        assert_eq!(info.codename, None);
+    }
+
+    #[test]
+    fn azurelinux_os_release() {
+        let root = "src/linux/tests/AzureLinux";
+
+        let info = retrieve(&DISTRIBUTIONS, root).unwrap();
+        assert_eq!(info.os_type(), Type::AzureLinux);
+        assert_eq!(info.version, Version::Semantic(3, 0, 0));
+        assert_eq!(info.edition, None);
+        assert_eq!(info.codename, None);
+    }
+
+    #[test]
+    fn azurelinux_os_release_unknown() {
+        let root = "src/linux/tests/AzureLinux_Unknown";
+
+        let info = retrieve(&DISTRIBUTIONS, root).unwrap();
+        assert_eq!(info.os_type(), Type::AzureLinux);
         assert_eq!(info.version, Version::Unknown);
         assert_eq!(info.edition, None);
         assert_eq!(info.codename, None);

--- a/os_info/src/linux/lsb_release.rs
+++ b/os_info/src/linux/lsb_release.rs
@@ -22,6 +22,7 @@ pub fn get() -> Option<Info> {
         Some("AOSC") => Type::AOSC,
         Some("Arch") => Type::Arch,
         Some("Artix") => Type::Artix,
+        Some("azurelinux") => Type::AzureLinux,
         Some("Bluefin") => Type::Bluefin,
         Some("cachyos") => Type::CachyOS,
         Some("CentOS") => Type::CentOS,
@@ -171,6 +172,14 @@ mod tests {
         assert_eq!(parse_results.distribution, Some("Artix".to_string()));
         assert_eq!(parse_results.version, Some("rolling".to_string()));
         assert_eq!(parse_results.codename, None);
+    }
+
+    #[test]
+    fn azurelinux() {
+        let parse_results = parse(azurelinux_file());
+        assert_eq!(parse_results.distribution, Some("azurelinux".to_string()));
+        assert_eq!(parse_results.version, Some("3.0.20240727".to_string()));
+        assert_eq!(parse_results.codename, Some("AzureLinux".to_string()));
     }
 
     #[test]
@@ -452,6 +461,14 @@ mod tests {
          Description:	Artix Linux\n\
          Release:	rolling\n\
          Codename:	n/a"
+    }
+
+    fn azurelinux_file() -> &'static str {
+        "\nLSB Version:	n/a\n\
+         Distributor ID:	azurelinux\n\
+         Description:	Azure Linux 3.0\n\
+         Release:	3.0.20240727\n\
+         Codename:	AzureLinux"
     }
 
     fn fedora_file() -> &'static str {

--- a/os_info/src/linux/mod.rs
+++ b/os_info/src/linux/mod.rs
@@ -34,6 +34,7 @@ mod tests {
             | Type::AOSC
             | Type::Arch
             | Type::Artix
+            | Type::AzureLinux
             | Type::Bazzite
             | Type::Bluefin
             | Type::CachyOS

--- a/os_info/src/linux/tests/AzureLinux/etc/os-release
+++ b/os_info/src/linux/tests/AzureLinux/etc/os-release
@@ -1,0 +1,9 @@
+NAME="Microsoft Azure Linux"
+VERSION="3.0.20240727"
+ID=azurelinux
+VERSION_ID="3.0"
+PRETTY_NAME="Microsoft Azure Linux 3.0"
+ANSI_COLOR="1;34"
+HOME_URL="https://aka.ms/azurelinux"
+BUG_REPORT_URL="https://aka.ms/azurelinux"
+SUPPORT_URL="https://aka.ms/azurelinux"

--- a/os_info/src/linux/tests/AzureLinux_Unknown/etc/os-release
+++ b/os_info/src/linux/tests/AzureLinux_Unknown/etc/os-release
@@ -1,0 +1,3 @@
+NAME="Microsoft Azure Linux"
+ID=azurelinux
+PRETTY_NAME="Microsoft Azure Linux"

--- a/os_info/src/os_type.rs
+++ b/os_info/src/os_type.rs
@@ -25,6 +25,8 @@ pub enum Type {
     AOSC,
     /// Arch Linux (<https://en.wikipedia.org/wiki/Arch_Linux>).
     Arch,
+    /// Azure Linux (<https://en.wikipedia.org/wiki/Azure_Linux>).
+    AzureLinux,
     /// Artix Linux (<https://en.wikipedia.org/wiki/Artix_Linux>).
     Artix,
     /// Bazzite (<https://en.wikipedia.org/wiki/Bazzite_(operating_system)>).
@@ -150,6 +152,7 @@ impl Display for Type {
             Type::Amazon => write!(f, "Amazon Linux AMI"),
             Type::AOSC => write!(f, "AOSC OS"),
             Type::Arch => write!(f, "Arch Linux"),
+            Type::AzureLinux => write!(f, "Azure Linux"),
             Type::Bazzite => write!(f, "Bazzite"),
             Type::Bluefin => write!(f, "Bluefin"),
             Type::CachyOS => write!(f, "CachyOS Linux"),
@@ -207,6 +210,7 @@ mod tests {
             (Type::AOSC, "AOSC OS"),
             (Type::Arch, "Arch Linux"),
             (Type::Artix, "Artix Linux"),
+            (Type::AzureLinux, "Azure Linux"),
             (Type::Bazzite, "Bazzite"),
             (Type::Bluefin, "Bluefin"),
             (Type::CachyOS, "CachyOS Linux"),


### PR DESCRIPTION
Adds support for [Azure Linux](https://en.wikipedia.org/wiki/Azure_Linux) distro to `os_info`.

Previous versions of this distro were known as "Mariner" (or some variation) and are already supported by this library. Version 3.0 switched to using this new name and new `ID` values in `os-release`.

----

_This is my first contribution to this project. I've tried to follow the pattern of previous changes, but please do let me know if there are additional guidelines or tests to follow. I wasn't quite certain if I should be updating `CHANGELOG.md` or if that would be updated by a maintainer -- let me know if you'd like me to revert that change.`_